### PR TITLE
4 simulator refractor estimators into tf layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,19 @@ simulator/
 ├── estimators/           # Forecasting models and factory
 │   ├── factory.py        # EstimatorFactory for creating estimators
 │   ├── configs/          # Estimator configurations
+│   ├── base_layer/       # Base TensorFlow layers
+│   ├── layers/           # TensorFlow layers for estimators
 │   └── models/           # Various estimator implementations
 ├── theoretical/          # Simulation engines
 │   └── simple_theoretical.py # Main simulation engine
 ├── examples/             # Usage examples
 │   └── estimators/       # EstimatorFactory examples
-├── tests/               # Unit tests
-├── utils/               # Utility functions
-└── docs/                # Documentation
-    └── variables.md     # Variable definitions
+├── tests/                # Unit tests
+│   └── estimators/       # Tests for estimators
+│       └── layers/       # Tests for TensorFlow layers
+├── utils/                # Utility functions
+└── docs/                 # Documentation
+    └── variables.md      # Variable definitions
 ```
 
 ## Quick Start

--- a/estimators/base_layer/hs_layer.py
+++ b/estimators/base_layer/hs_layer.py
@@ -39,12 +39,3 @@ class HSLayer(tf.keras.layers.Layer):
         Performs the forward pass
         """
         return tf.matmul(inputs, self.w) + self.b
-
-    def loss(self, y_true, y_pred):
-        # !TODO: Implement the HS loss function
-        # This is a normal squared loss
-        residuals = tf.abs(y_true - y_pred)
-
-        squared_loss = 0.5 * tf.square(residuals)
-
-        return tf.reduce_mean(squared_loss)

--- a/estimators/base_layer/hs_layer.py
+++ b/estimators/base_layer/hs_layer.py
@@ -1,0 +1,50 @@
+import tensorflow as tf
+
+
+class HSLayer(tf.keras.layers.Layer):
+    """
+    A Keras Layer for  linear regression using the HS loss.
+
+    This layer functions like a Dense layer but is designed to be trained
+    with its own loss function, making it less sensitive to outliers.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initializes the layer.
+        """
+        super().__init__(**kwargs)
+
+    def build(self, input_shape):
+        """
+        Creates the trainable weights of the layer (the coefficients).
+        This method is automatically called by Keras.
+        """
+        tf.print(f"Building HSLayer with input shape: {input_shape}")
+        self.w = self.add_weight(
+            shape=(input_shape[-1], 1),
+            initializer="glorot_uniform",
+            trainable=True,
+            name="weights",  # Regression coefficients
+        )
+        self.b = self.add_weight(
+            shape=(1,),
+            initializer="zeros",
+            trainable=True,
+            name="bias",  # Intercept term
+        )
+
+    def call(self, inputs):
+        """
+        Performs the forward pass
+        """
+        return tf.matmul(inputs, self.w) + self.b
+
+    def loss(self, y_true, y_pred):
+        # !TODO: Implement the HS loss function
+        # This is a normal squared loss
+        residuals = tf.abs(y_true - y_pred)
+
+        squared_loss = 0.5 * tf.square(residuals)
+
+        return tf.reduce_mean(squared_loss)

--- a/estimators/base_layer/logistic_layer.py
+++ b/estimators/base_layer/logistic_layer.py
@@ -42,8 +42,3 @@ class LogisticLayer(tf.keras.layers.Layer):
     def get_probabilities(self, inputs):
         logits = self.call(inputs)
         return tf.sigmoid(logits)
-
-    def loss(self, y_true, y_pred):
-        return tf.reduce_mean(
-            tf.nn.sigmoid_cross_entropy_with_logits(labels=y_true, logits=y_pred)
-        )

--- a/estimators/base_layer/logistic_layer.py
+++ b/estimators/base_layer/logistic_layer.py
@@ -1,0 +1,49 @@
+import numpy as np
+import tensorflow as tf
+
+
+class LogisticLayer(tf.keras.layers.Layer):
+    """
+    Keras Layer for logistic regression (logit computation).
+    Accepts a tensor input of shape [batch, num_features].
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def build(self, input_shape):
+        num_features = input_shape[-1]
+        self.w = self.add_weight(
+            shape=(num_features, 1),
+            initializer="glorot_uniform",
+            trainable=True,
+            name="weights",
+        )
+        self.b = self.add_weight(
+            shape=(1,),
+            initializer="zeros",
+            trainable=True,
+            name="bias",
+        )
+        super().build(input_shape)
+
+    def call(self, inputs):
+        """
+        Args:
+            inputs: tf.Tensor of shape [batch, num_features]
+        Returns:
+            tf.Tensor: logits, shape [batch, 1]
+        """
+        return tf.matmul(inputs, self.w) + self.b
+
+    def get_logits(self, inputs):
+        return self.call(inputs)
+
+    def get_probabilities(self, inputs):
+        logits = self.call(inputs)
+        return tf.sigmoid(logits)
+
+    def loss(self, y_true, y_pred):
+        return tf.reduce_mean(
+            tf.nn.sigmoid_cross_entropy_with_logits(labels=y_true, logits=y_pred)
+        )

--- a/estimators/base_layer/multinomial_layer.py
+++ b/estimators/base_layer/multinomial_layer.py
@@ -1,0 +1,52 @@
+import numpy as np
+import tensorflow as tf
+
+
+class MultinomialLayer(tf.keras.layers.Layer):
+    """
+    A Keras Layer for multinomial logistic regression that accepts a
+    single tensor as input.
+    """
+
+    def __init__(self, **kwargs):
+        """The layer no longer needs to know about feature names."""
+        super().__init__(**kwargs)
+
+    def build(self, input_shape):
+        """Creates weights based on the input tensor's shape."""
+        # The number of features is inferred directly from the input tensor.
+        num_features = input_shape[-1]
+
+        self.w = self.add_weight(
+            shape=(num_features,),
+            initializer="glorot_uniform",
+            trainable=True,
+            name="multinomial_weights",
+        )
+
+        self.intercepts = self.add_weight(
+            shape=(2,),
+            initializer="zeros",
+            trainable=True,
+            name="multinomial_intercepts",
+        )
+        super().build(input_shape)
+
+    def call(self, inputs: tf.Tensor):
+        """
+        Performs the forward pass with a pre-assembled tensor.
+
+        Args:
+            inputs (tf.Tensor): A tensor of shape [batch, num_features].
+
+        Returns:
+            tf.Tensor: A tensor of shape [batch, 2] containing the two logits.
+        """
+        # The call method is now much simpler.
+        # It works directly with the input tensor 'inputs'.
+        base_logit = tf.linalg.matvec(inputs, self.w)
+
+        logit1 = tf.reshape(base_logit + self.intercepts[0], [-1, 1])
+        logit2 = tf.reshape(base_logit + self.intercepts[1], [-1, 1])
+
+        return tf.concat([logit1, logit2], axis=1)

--- a/estimators/base_layer/multinomial_layer.py
+++ b/estimators/base_layer/multinomial_layer.py
@@ -18,13 +18,13 @@ class MultinomialLayer(tf.keras.layers.Layer):
         num_features = input_shape[-1]
 
         self.w = self.add_weight(
-            shape=(num_features,),
+            shape=(num_features, 1),
             initializer="glorot_uniform",
             trainable=True,
             name="multinomial_weights",
         )
 
-        self.intercepts = self.add_weight(
+        self.b = self.add_weight(
             shape=(2,),
             initializer="zeros",
             trainable=True,
@@ -44,9 +44,11 @@ class MultinomialLayer(tf.keras.layers.Layer):
         """
         # The call method is now much simpler.
         # It works directly with the input tensor 'inputs'.
-        base_logit = tf.linalg.matvec(inputs, self.w)
+        tf.print(f"Running MultinomialLayer with input shape: {inputs.shape}")
+        tf.print(f"Using weights shape: {self.w.shape}, bias shape: {self.w.shape}")
+        base_logit = tf.matmul(inputs, self.w)
 
-        logit1 = tf.reshape(base_logit + self.intercepts[0], [-1, 1])
-        logit2 = tf.reshape(base_logit + self.intercepts[1], [-1, 1])
+        logit1 = base_logit + self.b[0]
+        logit2 = base_logit + self.b[1]
 
         return tf.concat([logit1, logit2], axis=1)

--- a/estimators/base_layer/tobit_layer.py
+++ b/estimators/base_layer/tobit_layer.py
@@ -1,0 +1,64 @@
+import numpy as np
+import tensorflow as tf
+
+
+class TobitLayer(tf.keras.layers.Layer):
+    """
+    Keras Layer for Tobit regression.
+    Accepts a tensor input of shape [batch, num_features].
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def build(self, input_shape):
+        num_features = input_shape[-1]
+        self.w = self.add_weight(
+            shape=(num_features, 1),
+            initializer="glorot_uniform",
+            trainable=True,
+            name="weights",
+        )
+        self.b = self.add_weight(
+            shape=(1,),
+            initializer="zeros",
+            trainable=True,
+            name="bias",
+        )
+        self.scale = tf.Variable(
+            initial_value=1.0,
+            trainable=True,
+            name="scale",
+            dtype=tf.float32,
+        )
+        super().build(input_shape)
+
+    def _generate_logistic_error_term(self, shape: tf.TensorShape) -> tf.Tensor:
+        """
+        Generates a random error term from a logistic distribution with a
+        given scale. This is the method specified by your colleague.
+        """
+        epsilon = 1e-9
+        # Draw from a uniform distribution
+        u = tf.random.uniform(shape=shape, minval=epsilon, maxval=1.0 - epsilon)
+        # Inverse transform sampling for the logistic distribution
+        error = self.scale * tf.math.log(u / (1.0 - u))
+        return error
+
+    def call(self, inputs):
+        """
+        Args:
+            inputs: tf.Tensor of shape [batch, num_features]
+        Returns:
+            tf.Tensor: logits, shape [batch, 1]
+        """
+        deterministic_part = tf.matmul(inputs, self.w) + self.b
+        deterministic_part = tf.reshape(deterministic_part, [-1, 1])
+
+        num_firms = tf.shape(deterministic_part)[0]
+        error_term = self._generate_logistic_error_term(shape=[num_firms, 1])
+
+        # Latent variable
+        latent_variable = deterministic_part + error_term
+
+        return tf.maximum(0.0, latent_variable)

--- a/estimators/base_layer/tobit_layer.py
+++ b/estimators/base_layer/tobit_layer.py
@@ -25,11 +25,11 @@ class TobitLayer(tf.keras.layers.Layer):
             trainable=True,
             name="bias",
         )
-        self.scale = tf.Variable(
-            initial_value=1.0,
+        self.scale = self.add_weight(
+            shape=(1,),
+            initializer="ones",
             trainable=True,
             name="scale",
-            dtype=tf.float32,
         )
         super().build(input_shape)
 

--- a/estimators/layers/dca_layer.py
+++ b/estimators/layers/dca_layer.py
@@ -6,10 +6,25 @@ from estimators.configs.t7_dca_config import DCA_CONFIG
 
 
 class DCALayer(tf.keras.layers.Layer):
-    """Dedicated estimator for the 'dca' variable."""
+    """A dedicated TensorFlow layer for estimating the 'dca' variable.
+
+    This layer uses a single Heckman-style selection (HS) layer to model the 'dca'
+    variable. It takes a dictionary of input tensors, assembles them into a
+    single tensor, and passes them to the HS layer.
+
+    Attributes:
+        feature_names (list): A list of strings representing the names of the input
+            features required by the layer.
+        hs_layer (HSLayer): The underlying Heckman-style selection layer used for
+            the estimation.
+    """
 
     def __init__(self, **kwargs):
-        """Initializes DCALayer with feature names."""
+        """Initializes the DCALayer.
+
+        Args:
+            **kwargs: Additional keyword arguments for the parent `tf.keras.layers.Layer`.
+        """
         self.feature_names = [
             "sumcasht_1",
             "diffcasht_1",
@@ -37,10 +52,10 @@ class DCALayer(tf.keras.layers.Layer):
         self.hs_layer = HSLayer()
 
     def build(self, input_shape):
-        """Builds the layer weights.
+        """Creates the weights of the layer.
 
         Args:
-            input_shape: Shape of the input tensor.
+            input_shape (tf.TensorShape): The shape of the input tensor.
         """
         num_features = len(self.feature_names)
         tensor_input_shape = tf.TensorShape((None, num_features))
@@ -48,13 +63,13 @@ class DCALayer(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def _assemble_tensor(self, inputs):
-        """Converts input dict to an ordered tensor.
+        """Assembles the input dictionary into a single tensor.
 
         Args:
-            inputs: Dictionary mapping feature names to tensors.
+            inputs (dict): A dictionary mapping feature names to tensors.
 
         Returns:
-            tf.Tensor: Concatenated tensor of shape (batch_size, num_features).
+            tf.Tensor: A tensor of shape (batch_size, num_features).
         """
         feature_tensors = [
             tf.reshape(inputs[name], (-1, 1)) for name in self.feature_names
@@ -62,22 +77,22 @@ class DCALayer(tf.keras.layers.Layer):
         return tf.concat(feature_tensors, axis=1)
 
     def call(self, inputs):
-        """Runs the layer on input data.
+        """Defines the forward pass of the layer.
 
         Args:
-            inputs: Dictionary mapping feature names to tensors.
+            inputs (dict): A dictionary mapping feature names to tensors.
 
         Returns:
-            tf.Tensor: Output tensor after applying the layer.
+            tf.Tensor: The output tensor from the HS layer.
         """
         x_tensor = self._assemble_tensor(inputs)
         return self.hs_layer(x_tensor)
 
     def load_weights_from_cfg(self, cfg):
-        """Loads weights from a configuration dictionary.
+        """Loads the layer's weights from a configuration dictionary.
 
         Args:
-            cfg: Configuration dictionary with coefficients.
+            cfg (dict): A dictionary containing the model's configuration.
         """
         coefficients = cfg["steps"][0]["coefficients"]
         weights = []

--- a/estimators/layers/dca_layer.py
+++ b/estimators/layers/dca_layer.py
@@ -1,0 +1,133 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.hs_layer import HSLayer
+from estimators.configs.t7_dca_config import DCA_CONFIG
+
+
+class DCALayer(HSLayer):
+    """Dedicated estimator for the 'dca' variable."""
+
+    def __init__(self, **kwargs):
+        """Initializes DCALayer with feature names."""
+        self.feature_names = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "SMAt",
+            "IMAt",
+            "EDEPBUt",
+            "EDEPBUt2",
+            "IBUt",
+            "IBUt2",
+            "IBUt3",
+            "dclt_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        super(DCALayer, self).__init__(**kwargs)
+
+    def build(self, input_shape):
+        """Builds the layer weights.
+
+        Args:
+            input_shape: Shape of the input tensor.
+        """
+        num_features = len(self.feature_names)
+        tensor_input_shape = tf.TensorShape((None, num_features))
+        super().build(tensor_input_shape)
+
+    def _assemble_tensor(self, inputs):
+        """Converts input dict to an ordered tensor.
+
+        Args:
+            inputs: Dictionary mapping feature names to tensors.
+
+        Returns:
+            tf.Tensor: Concatenated tensor of shape (batch_size, num_features).
+        """
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.feature_names
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        """Runs the layer on input data.
+
+        Args:
+            inputs: Dictionary mapping feature names to tensors.
+
+        Returns:
+            tf.Tensor: Output tensor after applying the layer.
+        """
+        x_tensor = self._assemble_tensor(inputs)
+        return super().call(x_tensor)
+
+    def load_weights_from_dict(self, weights_dict):
+        """Loads weights from a provided Python dictionary.
+
+        Args:
+            weights_dict: Dictionary with 'weights' and 'bias' keys.
+        """
+        weights = weights_dict["weights"]
+        bias = weights_dict["bias"]
+        self.w.assign(weights)
+        self.b.assign(bias)
+        print("Weights for 'DCALayer' loaded successfully.")
+
+    def load_weights_from_cfg(self, config):
+        """Loads weights from a configuration dictionary.
+
+        Args:
+            config: Configuration dictionary with coefficients.
+        """
+        coefficients = config["steps"][0]["coefficients"]
+        weights = []
+        for name in self.feature_names:
+            if name in coefficients:
+                weights.append(coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+        weights = np.array(weights).reshape(len(self.feature_names), 1)
+        bias = np.array([coefficients["Intercept"]])
+        self.w.assign(weights)
+        self.b.assign(bias)
+        print("Weights for 'DCALayer' loaded successfully from config.")
+
+
+if __name__ == "__main__":
+
+    # 1. Instantiate the specific layer for 'dca'
+    dca_layer = DCALayer()
+    # 2. Build the layer by calling it on dummy data. This creates the weight tensors.
+    # The dummy input must be a dictionary with all the required feature keys.
+    dummy_input = {name: tf.zeros((13, 1)) for name in dca_layer.feature_names}
+    _ = dca_layer(dummy_input)
+
+    # 3. Call your new method to load the weights
+    dca_layer.load_weights_from_cfg(DCA_CONFIG)
+
+    # 4. Verification Step: Check if the weights were loaded correctly
+    loaded_weights = dca_layer.get_weights()
+    print("\n--- Verification ---")
+    print(f"Bias (Intercept) loaded: {loaded_weights[1][0]}")
+    print(
+        f"First weights weight (for '{dca_layer.feature_names[0]}') loaded: {loaded_weights[0]}"
+    )
+
+    # Now the dca_layer is ready for inference with pre-trained weights
+    test_input_dict = {
+        name: tf.constant([[2.0]], dtype=tf.float32)
+        for name in DCALayer().feature_names
+    }
+
+    prediction = dca_layer(test_input_dict)
+    tf.print("Prediction for test input:", prediction)

--- a/estimators/layers/dca_layer.py
+++ b/estimators/layers/dca_layer.py
@@ -73,40 +73,26 @@ class DCALayer(tf.keras.layers.Layer):
         x_tensor = self._assemble_tensor(inputs)
         return self.hs_layer(x_tensor)
 
-    def load_weights_from_dict(self, weights_dict):
-        """Loads weights from a provided Python dictionary.
-
-        Args:
-            weights_dict: Dictionary with 'weights' and 'bias' keys.
-        """
-        weights = weights_dict["weights"]
-        bias = weights_dict["bias"]
-        self.hs_layer.w.assign(weights)
-        self.hs_layer.b.assign(bias)
-        print("Weights for 'DCALayer' loaded successfully.")
-
-    def load_weights_from_cfg(self, config):
+    def load_weights_from_cfg(self, cfg):
         """Loads weights from a configuration dictionary.
 
         Args:
-            config: Configuration dictionary with coefficients.
+            cfg: Configuration dictionary with coefficients.
         """
-        coefficients = config["steps"][0]["coefficients"]
+        coefficients = cfg["steps"][0]["coefficients"]
         weights = []
         for name in self.feature_names:
             if name in coefficients:
                 weights.append(coefficients[name])
             else:
                 raise ValueError(f"Coefficient for {name} not found in config.")
-        weights = np.array(weights).reshape(len(self.feature_names), 1)
+        weights = np.array(weights, dtype=np.float32).reshape(
+            len(self.feature_names), 1
+        )
         bias = np.array([coefficients["Intercept"]])
         self.hs_layer.w.assign(weights)
         self.hs_layer.b.assign(bias)
         print("Weights for 'DCALayer' loaded successfully from config.")
-
-    def get_weights(self):
-        """Returns the weights from the HSLayer member."""
-        return self.hs_layer.get_weights()
 
 
 if __name__ == "__main__":

--- a/estimators/layers/dcl_layer.py
+++ b/estimators/layers/dcl_layer.py
@@ -2,10 +2,10 @@ import numpy as np
 import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
-from estimators.configs.t7_dca_config import DCA_CONFIG
+from estimators.configs.t9_dcl_config import DCL_CONFIG
 
 
-class DCALayer(tf.keras.layers.Layer):
+class DCLLayer(tf.keras.layers.Layer):
     """Dedicated estimator for the 'dca' variable."""
 
     def __init__(self, **kwargs):
@@ -21,10 +21,9 @@ class DCALayer(tf.keras.layers.Layer):
             "EDEPBUt2",
             "IBUt",
             "IBUt2",
-            "IBUt3",
-            "dclt_1",
             "ddmpat_1",
             "ddmpat_12",
+            "dcat",
             "dgnp",
             "FAAB",
             "Public",
@@ -92,31 +91,31 @@ class DCALayer(tf.keras.layers.Layer):
         bias = np.array([coefficients["Intercept"]])
         self.hs_layer.w.assign(weights)
         self.hs_layer.b.assign(bias)
-        print("Weights for 'DCALayer' loaded successfully from config.")
+        print("Weights for 'DCLayer' loaded successfully from config.")
 
 
 if __name__ == "__main__":
 
-    # 1. Instantiate the specific layer for 'dca'
-    dca_layer = DCALayer()
+    # 1. Instantiate the specific layer for 'dcl'
+    dcl_layer = DCLLayer()
     # 2. Build the layer by calling it on dummy data. This creates the weight tensors.
     # The dummy input must be a dictionary with all the required feature keys.
-    dummy_input = {name: tf.zeros((13, 1)) for name in dca_layer.feature_names}
-    _ = dca_layer(dummy_input)
+    dummy_input = {name: tf.zeros((13, 1)) for name in dcl_layer.feature_names}
+    _ = dcl_layer(dummy_input)
 
     # 3. Call your new method to load the weights
-    dca_layer.load_weights_from_cfg(DCA_CONFIG)
+    dcl_layer.load_weights_from_cfg(DCL_CONFIG)
 
     # 4. Verification Step: Check if the weights were loaded correctly
-    loaded_weights = dca_layer.get_weights()
+    loaded_weights = dcl_layer.get_weights()
     print("\n--- Verification ---")
     print(f"Bias (Intercept) loaded: {loaded_weights[1][0]}")
     print(
-        f"First weights weight (for '{dca_layer.feature_names[0]}') loaded: {loaded_weights[0]}"
+        f"First weights weight (for '{dcl_layer.feature_names[0]}') loaded: {loaded_weights[0]}"
     )
 
-    # Now the dca_layer is ready for inference with pre-trained weights
-    test_input = {name: tf.zeros((3, 1)) for name in dca_layer.feature_names}
+    # Now the dcl_layer is ready for inference with pre-trained weights
+    test_input = {name: tf.zeros((3, 1)) for name in dcl_layer.feature_names}
 
-    prediction = dca_layer(test_input)
+    prediction = dcl_layer(test_input)
     tf.print("Prediction for test input:", prediction)

--- a/estimators/layers/dcl_layer.py
+++ b/estimators/layers/dcl_layer.py
@@ -6,10 +6,25 @@ from estimators.configs.t9_dcl_config import DCL_CONFIG
 
 
 class DCLLayer(tf.keras.layers.Layer):
-    """Dedicated estimator for the 'dca' variable."""
+    """A dedicated TensorFlow layer for estimating the 'dcl' variable.
+
+    This layer uses a single Heckman-style selection (HS) layer to model the 'dcl'
+    variable. It takes a dictionary of input tensors, assembles them into a
+    single tensor, and passes them to the HS layer.
+
+    Attributes:
+        feature_names (list): A list of strings representing the names of the input
+            features required by the layer.
+        hs_layer (HSLayer): The underlying Heckman-style selection layer used for
+            the estimation.
+    """
 
     def __init__(self, **kwargs):
-        """Initializes DCALayer with feature names."""
+        """Initializes the DCLLayer.
+
+        Args:
+            **kwargs: Additional keyword arguments for the parent `tf.keras.layers.Layer`.
+        """
         self.feature_names = [
             "sumcasht_1",
             "diffcasht_1",
@@ -36,10 +51,10 @@ class DCLLayer(tf.keras.layers.Layer):
         self.hs_layer = HSLayer()
 
     def build(self, input_shape):
-        """Builds the layer weights.
+        """Creates the weights of the layer.
 
         Args:
-            input_shape: Shape of the input tensor.
+            input_shape (tf.TensorShape): The shape of the input tensor.
         """
         num_features = len(self.feature_names)
         tensor_input_shape = tf.TensorShape((None, num_features))
@@ -47,13 +62,13 @@ class DCLLayer(tf.keras.layers.Layer):
         super().build(input_shape)
 
     def _assemble_tensor(self, inputs):
-        """Converts input dict to an ordered tensor.
+        """Assembles the input dictionary into a single tensor.
 
         Args:
-            inputs: Dictionary mapping feature names to tensors.
+            inputs (dict): A dictionary mapping feature names to tensors.
 
         Returns:
-            tf.Tensor: Concatenated tensor of shape (batch_size, num_features).
+            tf.Tensor: A tensor of shape (batch_size, num_features).
         """
         feature_tensors = [
             tf.reshape(inputs[name], (-1, 1)) for name in self.feature_names
@@ -61,22 +76,22 @@ class DCLLayer(tf.keras.layers.Layer):
         return tf.concat(feature_tensors, axis=1)
 
     def call(self, inputs):
-        """Runs the layer on input data.
+        """Defines the forward pass of the layer.
 
         Args:
-            inputs: Dictionary mapping feature names to tensors.
+            inputs (dict): A dictionary mapping feature names to tensors.
 
         Returns:
-            tf.Tensor: Output tensor after applying the layer.
+            tf.Tensor: The output tensor from the HS layer.
         """
         x_tensor = self._assemble_tensor(inputs)
         return self.hs_layer(x_tensor)
 
     def load_weights_from_cfg(self, cfg):
-        """Loads weights from a configuration dictionary.
+        """Loads the layer's weights from a configuration dictionary.
 
         Args:
-            cfg: Configuration dictionary with coefficients.
+            cfg (dict): A dictionary containing the model's configuration.
         """
         coefficients = cfg["steps"][0]["coefficients"]
         weights = []

--- a/estimators/layers/dll_layer.py
+++ b/estimators/layers/dll_layer.py
@@ -7,8 +7,17 @@ from estimators.configs.t8_dll_config import DLL_CONFIG
 
 
 class DLLLayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'dll' variable.
+
+    This layer models a two-step process with a probability and a level component.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the DLLLayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/dll_layer.py
+++ b/estimators/layers/dll_layer.py
@@ -3,28 +3,22 @@ import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
 from estimators.base_layer.logistic_layer import LogisticLayer
-from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
+from estimators.configs.t8_dll_config import DLL_CONFIG
 
 
-class EDEPMALayer(tf.keras.layers.Layer):
+class DLLLayer(tf.keras.layers.Layer):
 
     def __init__(self, **kwargs):
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
             "ddmpat_1",
             "ddmpat_12",
-            "dclt_1",
-            "dgnp",
+            "ddmpat_13",
+            "DIMA",
+            "DIBU",
+            "Ddofa",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -35,19 +29,13 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_features = [
             "sumcasht_1",
             "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
             "ddmpat_1",
             "ddmpat_12",
-            "dclt_1",
-            "dgnp",
+            "ddmpat_13",
+            "DIMA",
+            "DIBU",
+            "Ddofa",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -61,54 +49,52 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer = HSLayer()
 
     def build(self):
+        all_features = len(self.feature_names)
+        all_features_tensor_shape = tf.TensorShape((None, all_features))
 
         num_prob_features = len(self.prob_features)
         num_level_features = len(self.level_features)
 
-        # Build the probability layer
         prob_input_shape = tf.TensorShape((None, num_prob_features))
-        self.prob_layer.build(prob_input_shape)
-
-        # Build the level layer
         level_input_shape = tf.TensorShape((None, num_level_features))
+
+        self.prob_layer.build(prob_input_shape)
         self.level_layer.build(level_input_shape)
 
-        all_input_shape = tf.TensorShape((None, len(self.feature_names)))
-        super().build(all_input_shape)
+        super().build(all_features_tensor_shape)
 
     def _assemble_prob_tensor(self, inputs):
         feature_tensors = [
-            tf.reshape(inputs[name], (-1, 1)) for name in self.prob_features
+            tf.reshape(inputs[feature], [-1, 1]) for feature in self.prob_features
         ]
         return tf.concat(feature_tensors, axis=1)
 
     def _assemble_level_tensor(self, inputs):
         feature_tensors = [
-            tf.reshape(inputs[name], (-1, 1)) for name in self.level_features
+            tf.reshape(inputs[feature], [-1, 1]) for feature in self.level_features
         ]
         return tf.concat(feature_tensors, axis=1)
 
     def call(self, inputs):
-        # check input contains all required features
         for name in self.feature_names:
             if name not in inputs:
-                raise ValueError(f"Missing input feature: {name}")
+                raise ValueError(f"Missing input required feature: {name}")
 
-        prob_tensor = self._assemble_prob_tensor(inputs)
         level_tensor = self._assemble_level_tensor(inputs)
+        prob_tensor = self._assemble_prob_tensor(inputs)
 
         prob_output = self.prob_layer(prob_tensor)
         level_output = self.level_layer(level_tensor)
 
-        P_hat = 1.0 - tf.math.exp(-tf.math.exp(prob_output))
-        num_firms = tf.shape(P_hat)[0]
-        U = tf.random.uniform(shape=[num_firms, 1], minval=0, maxval=1)
+        P_hat = tf.math.sigmoid(prob_output)
+        U = tf.random.uniform(shape=[tf.shape(P_hat)[0], 1], minval=0, maxval=1)
+
         should_report_level = tf.cast(P_hat > U, dtype=tf.float32)
 
         return level_output * should_report_level
 
     def load_weights_from_cfg(self, cfg):
-        # for prob layer
+        # Load weights for the probability layer
         prob_coefficients = cfg["steps"][0]["coefficients"]
         prob_weights = []
         for name in self.prob_features:
@@ -116,16 +102,13 @@ class EDEPMALayer(tf.keras.layers.Layer):
                 prob_weights.append(prob_coefficients[name])
             else:
                 raise ValueError(f"Missing coefficient for {name} in prob features.")
-
         prob_weights = np.array(prob_weights, dtype=np.float32).reshape(
             len(prob_weights), 1
         )
         prob_bias = np.array([prob_coefficients["Intercept"]], dtype=np.float32)
-
         self.prob_layer.w.assign(prob_weights)
         self.prob_layer.b.assign(prob_bias)
 
-        # for level layer
         level_coefficients = cfg["steps"][1]["coefficients"]
         level_weights = []
         for name in self.level_features:
@@ -133,34 +116,29 @@ class EDEPMALayer(tf.keras.layers.Layer):
                 level_weights.append(level_coefficients[name])
             else:
                 raise ValueError(f"Missing coefficient for {name} in level features.")
-
         level_weights = np.array(level_weights, dtype=np.float32).reshape(
             len(level_weights), 1
         )
         level_bias = np.array([level_coefficients["Intercept"]], dtype=np.float32)
-
         self.level_layer.w.assign(level_weights)
         self.level_layer.b.assign(level_bias)
 
-        print("Weights for 'EDEPMALayer' loaded successfully.")
+        print("DLLLayer weights loaded from configuration.")
 
 
 if __name__ == "__main__":
-    # 1. Instantiate the EDEPMALayer
-    edepma_layer = EDEPMALayer()
-    dummy_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
-    _ = edepma_layer(dummy_input)
+    dll_layer = DLLLayer()
 
-    edepma_layer.load_weights_from_cfg(EDEPMA_CONFIG)
+    dummy_input = {name: tf.zeros((3, 1)) for name in dll_layer.feature_names}
+    _ = dll_layer(dummy_input)
 
-    loaded_weights = edepma_layer.get_weights()
+    dll_layer.load_weights_from_cfg(DLL_CONFIG)
+
+    loaded_weights = dll_layer.get_weights()
     print("Loaded Weights:", loaded_weights)
-    print("EDEPMALayer initialized and weights loaded successfully.")
+    print("DLLLayer initialized and weights loaded successfully.")
 
-    test_input = {
-        name: tf.random.uniform((1, 1)) for name in edepma_layer.feature_names
-    }
-    test_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
-
-    prediction = edepma_layer(test_input)
+    test_input = {name: tf.random.uniform((3, 1)) for name in dll_layer.feature_names}
+    prediction = dll_layer(test_input)
     print("Prediction:", prediction)
+    print("Output shape:", prediction.shape)

--- a/estimators/layers/dofa_layer.py
+++ b/estimators/layers/dofa_layer.py
@@ -7,8 +7,18 @@ from estimators.configs.t6_dofa_config import DOFA_CONFIG
 
 
 class DOFALayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'dofa' variable.
+
+    This layer models a four-step process with positive and negative probability
+    and level components.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the DOFALayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.pos_prob_features = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/dofa_layer.py
+++ b/estimators/layers/dofa_layer.py
@@ -1,0 +1,253 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.hs_layer import HSLayer
+from estimators.base_layer.logistic_layer import LogisticLayer
+from estimators.configs.t6_dofa_config import DOFA_CONFIG
+
+
+class DOFALayer(tf.keras.layers.Layer):
+
+    def __init__(self, **kwargs):
+        self.pos_prob_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "ddmpat_13",
+            "DIMA",
+            "DIBU",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.neg_prob_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "DIMA",
+            "DIBU",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.pos_level_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "ddmpat_13",
+            "DIMA",
+            "DIBU",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.neg_level_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "DIMA",
+            "DIBU",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.feature_names = set(
+            self.pos_prob_features
+            + self.neg_prob_features
+            + self.pos_level_features
+            + self.neg_level_features
+        )
+
+        super().__init__(**kwargs)
+        self.pos_prob_layer = LogisticLayer()
+        self.neg_prob_layer = LogisticLayer()
+        self.pos_level_layer = HSLayer()
+        self.neg_level_layer = HSLayer()
+
+    def build(self):
+        num_pos_prob_features = len(self.pos_prob_features)
+        num_neg_prob_features = len(self.neg_prob_features)
+        num_pos_level_features = len(self.pos_level_features)
+        num_neg_level_features = len(self.neg_level_features)
+
+        # Build the probability layer
+        pos_prob_input_shape = tf.TensorShape((None, num_pos_prob_features))
+        self.pos_prob_layer.build(pos_prob_input_shape)
+        neg_prob_input_shape = tf.TensorShape((None, num_neg_prob_features))
+        self.neg_prob_layer.build(neg_prob_input_shape)
+
+        # Build the level layer
+        pos_level_input_shape = tf.TensorShape((None, num_pos_level_features))
+        self.pos_level_layer.build(pos_level_input_shape)
+        neg_level_input_shape = tf.TensorShape((None, num_neg_level_features))
+        self.neg_level_layer.build(neg_level_input_shape)
+
+        all_input_shape = tf.TensorShape((None, len(self.feature_names)))
+        super().build(all_input_shape)
+
+    def _assemble_pos_prob_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.pos_prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_neg_prob_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.neg_prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_pos_level_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.pos_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_neg_level_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.neg_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        # check input contains all required features
+        for name in self.feature_names:
+            if name not in inputs:
+                raise ValueError(f"Missing input feature: {name}")
+
+        pos_prob_tensor = self._assemble_pos_prob_tensor(inputs)
+        neg_prob_tensor = self._assemble_neg_prob_tensor(inputs)
+        pos_level_tensor = self._assemble_pos_level_tensor(inputs)
+        neg_level_tensor = self._assemble_neg_level_tensor(inputs)
+
+        eta_pos = self.pos_prob_layer(pos_prob_tensor)
+        eta_neg = self.neg_prob_layer(neg_prob_tensor)
+        pos_levels = self.pos_level_layer(pos_level_tensor)
+        neg_levels = self.neg_level_layer(neg_level_tensor)
+
+        P_hat1 = tf.sigmoid(eta_pos)
+        P_hat2 = tf.sigmoid(eta_neg)
+        P_hat1 = tf.minimum(P_hat1, P_hat2)
+
+        num_firms = tf.shape(P_hat1)[0]
+        U = tf.random.uniform(shape=(num_firms, 1), minval=0, maxval=1)
+
+        is_positive = tf.cast(U < P_hat1, dtype=tf.float32)
+        is_zero = tf.cast((U >= P_hat1) & (U < P_hat2), dtype=tf.float32)
+        is_negative = tf.cast(U >= P_hat2, dtype=tf.float32)
+
+        final_value = (
+            (is_positive * pos_levels) + (is_negative * neg_levels) + (is_zero * 0.0)
+        )
+
+        return final_value
+
+    def load_weights_from_cfg(self, cfg):
+        # for prob layer
+        pos_prob_coefficients = cfg["steps"][0]["coefficients"]
+        pos_prob_weights = []
+        for name in self.pos_prob_features:
+            if name in pos_prob_coefficients:
+                pos_prob_weights.append(pos_prob_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in prob features.")
+
+        pos_prob_weights = np.array(pos_prob_weights, dtype=np.float32).reshape(
+            len(pos_prob_weights), 1
+        )
+        pos_prob_bias = np.array([pos_prob_coefficients["Intercept"]], dtype=np.float32)
+
+        self.pos_prob_layer.w.assign(pos_prob_weights)
+        self.pos_prob_layer.b.assign(pos_prob_bias)
+
+        neg_prob_coefficients = cfg["steps"][1]["coefficients"]
+        neg_prob_weights = []
+        for name in self.neg_prob_features:
+            if name in neg_prob_coefficients:
+                neg_prob_weights.append(neg_prob_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in prob features.")
+
+        neg_prob_weights = np.array(neg_prob_weights, dtype=np.float32).reshape(
+            len(neg_prob_weights), 1
+        )
+        neg_prob_bias = np.array([neg_prob_coefficients["Intercept"]], dtype=np.float32)
+
+        self.neg_prob_layer.w.assign(neg_prob_weights)
+        self.neg_prob_layer.b.assign(neg_prob_bias)
+
+        pos_level_coefficients = cfg["steps"][2]["coefficients"]
+        pos_level_weights = []
+        for name in self.pos_level_features:
+            if name in pos_level_coefficients:
+                pos_level_weights.append(pos_level_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in level features.")
+
+        pos_level_weights = np.array(pos_level_weights, dtype=np.float32).reshape(
+            len(pos_level_weights), 1
+        )
+        pos_level_bias = np.array(
+            [pos_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.pos_level_layer.w.assign(pos_level_weights)
+        self.pos_level_layer.b.assign(pos_level_bias)
+
+        neg_level_coefficients = cfg["steps"][3]["coefficients"]
+        neg_level_weights = []
+        for name in self.neg_level_features:
+            if name in neg_level_coefficients:
+                neg_level_weights.append(neg_level_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in level features.")
+
+        neg_level_weights = np.array(neg_level_weights, dtype=np.float32).reshape(
+            len(neg_level_weights), 1
+        )
+        neg_level_bias = np.array(
+            [neg_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.neg_level_layer.w.assign(neg_level_weights)
+        self.neg_level_layer.b.assign(neg_level_bias)
+
+        print("Weights for 'DOFALayer' loaded successfully.")
+
+
+if __name__ == "__main__":
+    # 1. Instantiate the DOFALayer
+    dofa_layer = DOFALayer()
+    dummy_input = {name: tf.zeros((3, 1)) for name in dofa_layer.feature_names}
+    _ = dofa_layer(dummy_input)
+
+    dofa_layer.load_weights_from_cfg(DOFA_CONFIG)
+
+    loaded_weights = dofa_layer.get_weights()
+    print("Loaded Weights:", loaded_weights)
+    print("DOFALayer initialized and weights loaded successfully.")
+
+    test_input = {name: tf.zeros((3, 1)) for name in dofa_layer.feature_names}
+
+    prediction = dofa_layer(test_input)
+    print("Prediction:", prediction)

--- a/estimators/layers/dour_layer.py
+++ b/estimators/layers/dour_layer.py
@@ -1,0 +1,211 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.hs_layer import HSLayer
+from estimators.base_layer.multinomial_layer import MultinomialLayer
+from estimators.configs.t17_dour_config import DOUR_CONFIG
+
+
+class DOURLayer(tf.keras.layers.Layer):
+    def __init__(self, **kwargs):
+        self.prob_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "ddmpat_13",
+            "DTDEPMA",
+            "DZPF",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+
+        self.pos_level_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "DTDEPMA",
+            "DZPF",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.neg_level_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "DTDEPMA",
+            "DZPF",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.feature_names = set(
+            self.prob_features + self.pos_level_features + self.neg_level_features
+        )
+        super().__init__(**kwargs)
+        self.prob_layer = MultinomialLayer()
+        self.pos_level_layer = HSLayer()
+        self.neg_level_layer = HSLayer()
+
+    def build(self):
+        num_prob_features = len(self.prob_features)
+        num_pos_level_features = len(self.pos_level_features)
+        num_neg_level_features = len(self.neg_level_features)
+
+        tensor_input_shape = tf.TensorShape((None, num_prob_features))
+        self.prob_layer.build(tensor_input_shape)
+
+        pos_level_input_shape = tf.TensorShape((None, num_pos_level_features))
+        self.pos_level_layer.build(pos_level_input_shape)
+
+        neg_level_input_shape = tf.TensorShape((None, num_neg_level_features))
+        self.neg_level_layer.build(neg_level_input_shape)
+
+        super().build((None, len(self.feature_names)))
+
+    def _assemble_prob_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for probability features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_pos_level_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for positive level features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.pos_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_neg_level_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for negative level features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.neg_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        """Runs the layer on input data."""
+        prob_tensor = self._assemble_prob_tensor(inputs)
+        pos_level_tensor = self._assemble_pos_level_tensor(inputs)
+        neg_level_tensor = self._assemble_neg_level_tensor(inputs)
+
+        pos_level = self.pos_level_layer(pos_level_tensor)
+        neg_level = self.neg_level_layer(neg_level_tensor)
+
+        prob = self.prob_layer(prob_tensor)
+
+        eta1 = prob[:, 0:1]
+        eta2 = prob[:, 1:2]
+
+        pos_level = tf.maximum(pos_level, 0.0)
+        neg_level = tf.minimum(neg_level, 0.0)
+
+        eta2 = tf.maximum(eta1, eta2)
+
+        P_hat1 = tf.sigmoid(eta1)
+        P_hat2 = tf.sigmoid(eta2)
+
+        num_firms = tf.shape(P_hat1)[0]
+        U = tf.random.uniform(shape=[num_firms, 1], minval=0, maxval=1)
+
+        is_negative = tf.cast(U < P_hat1, dtype=tf.float32)
+        is_zero = tf.cast((U >= P_hat1) & (U < P_hat2), dtype=tf.float32)
+        is_positive = tf.cast(U >= P_hat2, dtype=tf.float32)
+
+        final_value = (
+            (is_positive * pos_level) + (is_negative * neg_level) + (is_zero * 0.0)
+        )
+
+        return final_value
+
+    def load_weights_from_cfg(self, cfg):
+        """Loads weights from a configuration dictionary."""
+        prob_coefficients = cfg["steps"][0]["coefficients"]
+        prob_weights = []
+        for name in self.prob_features:
+            if name in prob_coefficients:
+                prob_weights.append(prob_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        prob_weights = np.array(prob_weights, dtype=np.float32).reshape(
+            len(self.prob_features), 1
+        )
+        prob_bias = np.array(prob_coefficients["Intercept"], dtype=np.float32)
+
+        self.prob_layer.w.assign(prob_weights)
+        self.prob_layer.b.assign(prob_bias)
+
+        pos_level_coefficients = cfg["steps"][1]["coefficients"]
+        pos_level_weights = []
+        for name in self.pos_level_features:
+            if name in pos_level_coefficients:
+                pos_level_weights.append(pos_level_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        pos_level_weights = np.array(pos_level_weights, dtype=np.float32).reshape(
+            len(self.pos_level_features), 1
+        )
+        pos_level_bias = np.array(
+            [pos_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.pos_level_layer.w.assign(pos_level_weights)
+        self.pos_level_layer.b.assign(pos_level_bias)
+
+        neg_level_coefficients = cfg["steps"][2]["coefficients"]
+        neg_level_weights = []
+        for name in self.neg_level_features:
+            if name in neg_level_coefficients:
+                neg_level_weights.append(neg_level_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        neg_level_weights = np.array(neg_level_weights, dtype=np.float32).reshape(
+            len(self.neg_level_features), 1
+        )
+        neg_level_bias = np.array(
+            [neg_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.neg_level_layer.w.assign(neg_level_weights)
+        self.neg_level_layer.b.assign(neg_level_bias)
+
+
+if __name__ == "__main__":
+    # 1. Instantiate the DOURLayer
+    tf_layer = DOURLayer()
+    dummy_input = {name: tf.zeros((5, 1)) for name in tf_layer.feature_names}
+    _ = tf_layer(dummy_input)
+
+    # 2. Load weights from configuration
+    tf_layer.load_weights_from_cfg(DOUR_CONFIG)
+
+    print("DOURLayer initialized and weights loaded successfully.")
+
+    # 3. Test the layer with dummy input
+    prediction = tf_layer(dummy_input)
+    print("Prediction:", prediction)
+
+    # 4. Print the weights to verify
+    print("Weights:", tf_layer.get_weights())
+
+    # 5. Print the feature names to verify
+    print("Feature Names:", tf_layer.feature_names)

--- a/estimators/layers/dour_layer.py
+++ b/estimators/layers/dour_layer.py
@@ -7,7 +7,18 @@ from estimators.configs.t17_dour_config import DOUR_CONFIG
 
 
 class DOURLayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'dour' variable.
+
+    This layer models a three-step process with a probability and positive/negative
+    level components.
+    """
+
     def __init__(self, **kwargs):
+        """Initializes the DOURLayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/drr_layer.py
+++ b/estimators/layers/drr_layer.py
@@ -3,28 +3,21 @@ import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
 from estimators.base_layer.logistic_layer import LogisticLayer
-from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
+from estimators.configs.t11_drr_config import DRR_CONFIG
 
 
-class EDEPMALayer(tf.keras.layers.Layer):
+class DRRLayer(tf.keras.layers.Layer):
 
     def __init__(self, **kwargs):
         self.prob_features = [
-            "sumcasht_1",
-            "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
-            "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
-            "dgnp",
+            "ddmcasht_1",
+            "ddmcasht_12",
+            "DIMA",
+            "DIBU",
+            "Ddofa",
+            "Ddll",
+            "Ddsc",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -33,21 +26,14 @@ class EDEPMALayer(tf.keras.layers.Layer):
             "marketw",
         ]
         self.level_features = [
-            "sumcasht_1",
-            "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
-            "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
-            "dgnp",
+            "ddmcasht_1",
+            "ddmcasht_12",
+            "DIMA",
+            "DIBU",
+            "Ddofa",
+            "Ddll",
+            "Ddsc",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -61,7 +47,6 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer = HSLayer()
 
     def build(self):
-
         num_prob_features = len(self.prob_features)
         num_level_features = len(self.level_features)
 
@@ -142,25 +127,25 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer.w.assign(level_weights)
         self.level_layer.b.assign(level_bias)
 
-        print("Weights for 'EDEPMALayer' loaded successfully.")
+        print("Weights for 'DRRLayer' loaded successfully.")
 
 
 if __name__ == "__main__":
-    # 1. Instantiate the EDEPMALayer
-    edepma_layer = EDEPMALayer()
-    dummy_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
-    _ = edepma_layer(dummy_input)
+    # 1. Instantiate the DRRLayer
+    DRRLayer = DRRLayer()
+    dummy_input = {name: tf.zeros((3, 1)) for name in DRRLayer.feature_names}
+    _ = DRRLayer(dummy_input)
 
-    edepma_layer.load_weights_from_cfg(EDEPMA_CONFIG)
+    DRRLayer.load_weights_from_cfg(DRR_CONFIG)
 
-    loaded_weights = edepma_layer.get_weights()
+    loaded_weights = DRRLayer.get_weights()
     print("Loaded Weights:", loaded_weights)
-    print("EDEPMALayer initialized and weights loaded successfully.")
+    print("DRRLayer initialized and weights loaded successfully.")
 
     test_input = {
-        name: tf.random.uniform((1, 1)) for name in edepma_layer.feature_names
+        name: tf.random.uniform((3, 1), minval=-100, maxval=100)
+        for name in DRRLayer.feature_names
     }
-    test_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
 
-    prediction = edepma_layer(test_input)
+    prediction = DRRLayer(test_input)
     print("Prediction:", prediction)

--- a/estimators/layers/drr_layer.py
+++ b/estimators/layers/drr_layer.py
@@ -7,8 +7,17 @@ from estimators.configs.t11_drr_config import DRR_CONFIG
 
 
 class DRRLayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'drr' variable.
+
+    This layer models a two-step process with a probability and a level component.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the DRRLayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "ddmcasht_1",
             "ddmcasht_12",

--- a/estimators/layers/dsc_layer.py
+++ b/estimators/layers/dsc_layer.py
@@ -7,8 +7,18 @@ from estimators.configs.t10_dsc_config import DSC_CONFIG
 
 
 class DSCLayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'dsc' variable.
+
+    This layer models a four-step process with positive and negative probability
+    and level components.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the DSCLayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.pos_prob_features = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/dsc_layer.py
+++ b/estimators/layers/dsc_layer.py
@@ -1,0 +1,260 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.hs_layer import HSLayer
+from estimators.base_layer.logistic_layer import LogisticLayer
+from estimators.configs.t10_dsc_config import DSC_CONFIG
+
+
+class DSCLayer(tf.keras.layers.Layer):
+
+    def __init__(self, **kwargs):
+        self.pos_prob_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "ddmpat_13",
+            "DIMA",
+            "DIBU",
+            "Ddofa",
+            "Ddll",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.neg_prob_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "ddmpat_13",
+            "DIMA",
+            "DIBU",
+            "Ddofa",
+            "Ddll",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.pos_level_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "DIMA",
+            "DIBU",
+            "Ddofa",
+            "Ddll",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.neg_level_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "ddmpat_1",
+            "DIMA",
+            "DIBU",
+            "Ddofa",
+            "Ddll",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.feature_names = set(
+            self.pos_prob_features
+            + self.neg_prob_features
+            + self.pos_level_features
+            + self.neg_level_features
+        )
+
+        super().__init__(**kwargs)
+        self.pos_prob_layer = LogisticLayer()
+        self.neg_prob_layer = LogisticLayer()
+        self.pos_level_layer = HSLayer()
+        self.neg_level_layer = HSLayer()
+
+    def build(self):
+        num_pos_prob_features = len(self.pos_prob_features)
+        num_neg_prob_features = len(self.neg_prob_features)
+        num_pos_level_features = len(self.pos_level_features)
+        num_neg_level_features = len(self.neg_level_features)
+
+        # Build the probability layer
+        pos_prob_input_shape = tf.TensorShape((None, num_pos_prob_features))
+        self.pos_prob_layer.build(pos_prob_input_shape)
+        neg_prob_input_shape = tf.TensorShape((None, num_neg_prob_features))
+        self.neg_prob_layer.build(neg_prob_input_shape)
+
+        # Build the level layer
+        pos_level_input_shape = tf.TensorShape((None, num_pos_level_features))
+        self.pos_level_layer.build(pos_level_input_shape)
+        neg_level_input_shape = tf.TensorShape((None, num_neg_level_features))
+        self.neg_level_layer.build(neg_level_input_shape)
+
+        all_input_shape = tf.TensorShape((None, len(self.feature_names)))
+        super().build(all_input_shape)
+
+    def _assemble_pos_prob_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.pos_prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_neg_prob_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.neg_prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_pos_level_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.pos_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_neg_level_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.neg_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        # check input contains all required features
+        for name in self.feature_names:
+            if name not in inputs:
+                raise ValueError(f"Missing input feature: {name}")
+
+        pos_prob_tensor = self._assemble_pos_prob_tensor(inputs)
+        neg_prob_tensor = self._assemble_neg_prob_tensor(inputs)
+        pos_level_tensor = self._assemble_pos_level_tensor(inputs)
+        neg_level_tensor = self._assemble_neg_level_tensor(inputs)
+
+        eta_pos = self.pos_prob_layer(pos_prob_tensor)
+        eta_neg = self.neg_prob_layer(neg_prob_tensor)
+        pos_levels = self.pos_level_layer(pos_level_tensor)
+        neg_levels = self.neg_level_layer(neg_level_tensor)
+
+        P_hat1 = tf.sigmoid(eta_pos)
+        P_hat2 = tf.sigmoid(eta_neg)
+        P_hat1 = tf.minimum(P_hat1, P_hat2)
+
+        num_firms = tf.shape(P_hat1)[0]
+        U = tf.random.uniform(shape=(num_firms, 1), minval=0, maxval=1)
+
+        is_positive = tf.cast(U < P_hat1, dtype=tf.float32)
+        is_zero = tf.cast((U >= P_hat1) & (U < P_hat2), dtype=tf.float32)
+        is_negative = tf.cast(U >= P_hat2, dtype=tf.float32)
+
+        final_value = (
+            (is_positive * pos_levels) + (is_negative * neg_levels) + (is_zero * 0.0)
+        )
+
+        return final_value
+
+    def load_weights_from_cfg(self, cfg):
+        # for prob layer
+        pos_prob_coefficients = cfg["steps"][0]["coefficients"]
+        pos_prob_weights = []
+        for name in self.pos_prob_features:
+            if name in pos_prob_coefficients:
+                pos_prob_weights.append(pos_prob_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in prob features.")
+
+        pos_prob_weights = np.array(pos_prob_weights, dtype=np.float32).reshape(
+            len(pos_prob_weights), 1
+        )
+        pos_prob_bias = np.array([pos_prob_coefficients["Intercept"]], dtype=np.float32)
+
+        self.pos_prob_layer.w.assign(pos_prob_weights)
+        self.pos_prob_layer.b.assign(pos_prob_bias)
+
+        neg_prob_coefficients = cfg["steps"][1]["coefficients"]
+        neg_prob_weights = []
+        for name in self.neg_prob_features:
+            if name in neg_prob_coefficients:
+                neg_prob_weights.append(neg_prob_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in prob features.")
+
+        neg_prob_weights = np.array(neg_prob_weights, dtype=np.float32).reshape(
+            len(neg_prob_weights), 1
+        )
+        neg_prob_bias = np.array([neg_prob_coefficients["Intercept"]], dtype=np.float32)
+
+        self.neg_prob_layer.w.assign(neg_prob_weights)
+        self.neg_prob_layer.b.assign(neg_prob_bias)
+
+        pos_level_coefficients = cfg["steps"][2]["coefficients"]
+        pos_level_weights = []
+        for name in self.pos_level_features:
+            if name in pos_level_coefficients:
+                pos_level_weights.append(pos_level_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in level features.")
+
+        pos_level_weights = np.array(pos_level_weights, dtype=np.float32).reshape(
+            len(pos_level_weights), 1
+        )
+        pos_level_bias = np.array(
+            [pos_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.pos_level_layer.w.assign(pos_level_weights)
+        self.pos_level_layer.b.assign(pos_level_bias)
+
+        neg_level_coefficients = cfg["steps"][3]["coefficients"]
+        neg_level_weights = []
+        for name in self.neg_level_features:
+            if name in neg_level_coefficients:
+                neg_level_weights.append(neg_level_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in level features.")
+
+        neg_level_weights = np.array(neg_level_weights, dtype=np.float32).reshape(
+            len(neg_level_weights), 1
+        )
+        neg_level_bias = np.array(
+            [neg_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.neg_level_layer.w.assign(neg_level_weights)
+        self.neg_level_layer.b.assign(neg_level_bias)
+
+        print("Weights for 'DSCLayer' loaded successfully.")
+
+
+if __name__ == "__main__":
+    # 1. Instantiate the DSCLayer
+    tflayer = DSCLayer()
+    dummy_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
+    _ = tflayer(dummy_input)
+
+    tflayer.load_weights_from_cfg(DSC_CONFIG)
+
+    loaded_weights = tflayer.get_weights()
+    print("Loaded Weights:", loaded_weights)
+    print("DSCLayer initialized and weights loaded successfully.")
+
+    test_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
+
+    prediction = tflayer(test_input)
+    print("Prediction:", prediction)

--- a/estimators/layers/edepbu_layer.py
+++ b/estimators/layers/edepbu_layer.py
@@ -3,26 +3,23 @@ import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
 from estimators.base_layer.logistic_layer import LogisticLayer
-from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
+from estimators.configs.t4_edepbu_config import EDEPBU_CONFIG
 
 
-class EDEPMALayer(tf.keras.layers.Layer):
+class EDEPBULayer(tf.keras.layers.Layer):
 
     def __init__(self, **kwargs):
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "SMAt",
+            "IMAt",
+            "BUt_1",
+            "BUt_12",
             "dcat_1",
             "ddmpat_1",
-            "ddmpat_12",
             "dclt_1",
             "dgnp",
             "FAAB",
@@ -35,18 +32,15 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_features = [
             "sumcasht_1",
             "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
+            "sumcaclt_1",
+            "diffcaclt_1",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "SMAt",
+            "SMAt2",
+            "IMAt",
+            "BUt_1",
             "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
             "dgnp",
             "FAAB",
             "Public",
@@ -121,11 +115,10 @@ class EDEPMALayer(tf.keras.layers.Layer):
             len(prob_weights), 1
         )
         prob_bias = np.array([prob_coefficients["Intercept"]], dtype=np.float32)
-
         self.prob_layer.w.assign(prob_weights)
         self.prob_layer.b.assign(prob_bias)
 
-        # for level layer
+        # for prob layer
         level_coefficients = cfg["steps"][1]["coefficients"]
         level_weights = []
         for name in self.level_features:
@@ -142,25 +135,23 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer.w.assign(level_weights)
         self.level_layer.b.assign(level_bias)
 
-        print("Weights for 'EDEPMALayer' loaded successfully.")
+        print("Weights for 'EDEPBULayer' loaded successfully.")
 
 
 if __name__ == "__main__":
-    # 1. Instantiate the EDEPMALayer
-    edepma_layer = EDEPMALayer()
-    dummy_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
-    _ = edepma_layer(dummy_input)
+    # 1. Instantiate the EDEPBULayer
+    var_layer = EDEPBULayer()
+    dummy_input = {name: tf.zeros((1, 1)) for name in var_layer.feature_names}
+    _ = var_layer(dummy_input)
 
-    edepma_layer.load_weights_from_cfg(EDEPMA_CONFIG)
+    var_layer.load_weights_from_cfg(EDEPBU_CONFIG)
 
-    loaded_weights = edepma_layer.get_weights()
+    loaded_weights = var_layer.get_weights()
     print("Loaded Weights:", loaded_weights)
-    print("EDEPMALayer initialized and weights loaded successfully.")
+    print("EDEPBULayer initialized and weights loaded successfully.")
 
-    test_input = {
-        name: tf.random.uniform((1, 1)) for name in edepma_layer.feature_names
-    }
-    test_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
+    test_input = {name: tf.random.uniform((1, 1)) for name in var_layer.feature_names}
+    test_input = {name: tf.zeros((1, 1)) for name in var_layer.feature_names}
 
-    prediction = edepma_layer(test_input)
+    prediction = var_layer(test_input)
     print("Prediction:", prediction)

--- a/estimators/layers/edepbu_layer.py
+++ b/estimators/layers/edepbu_layer.py
@@ -7,8 +7,17 @@ from estimators.configs.t4_edepbu_config import EDEPBU_CONFIG
 
 
 class EDEPBULayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'edepbu' variable.
+
+    This layer models a two-step process with a probability and a level component.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the EDEPBULayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/edepma_layer.py
+++ b/estimators/layers/edepma_layer.py
@@ -1,0 +1,162 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.hs_layer import HSLayer
+from estimators.base_layer.logistic_layer import LogisticLayer
+from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
+
+
+class EDEPMALayer(tf.keras.layers.Layer):
+
+    def __init__(self, **kwargs):
+        self.prob_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "TDEPMAt_1",
+            "MAt_1",
+            "I_MAt_1",
+            "I_MAt_12",
+            "EDEPBUt_1",
+            "EDEPBUt_12",
+            "ddmtdmt_1",
+            "ddmtdmt_12",
+            "dcat_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "dclt_1",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.level_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "TDEPMAt_1",
+            "MAt_1",
+            "I_MAt_1",
+            "I_MAt_12",
+            "EDEPBUt_1",
+            "EDEPBUt_12",
+            "ddmtdmt_1",
+            "ddmtdmt_12",
+            "dcat_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "dclt_1",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.feature_names = set(self.prob_features + self.level_features)
+        super().__init__(**kwargs)
+        self.prob_layer = LogisticLayer()
+        self.level_layer = HSLayer()
+
+    def build(self, input_shape):
+
+        num_prob_features = len(self.prob_features)
+        num_level_features = len(self.level_features)
+
+        # Build the probability layer
+        prob_input_shape = tf.TensorShape((None, num_prob_features))
+        self.prob_layer.build(prob_input_shape)
+
+        # Build the level layer
+        level_input_shape = tf.TensorShape((None, num_level_features))
+        self.level_layer.build(level_input_shape)
+
+    def _assemble_prob_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_level_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        # check input contains all required features
+        for name in self.feature_names:
+            if name not in inputs:
+                raise ValueError(f"Missing input feature: {name}")
+
+        prob_tensor = self._assemble_prob_tensor(inputs)
+        level_tensor = self._assemble_level_tensor(inputs)
+
+        prob_output = self.prob_layer(prob_tensor)
+        level_output = self.level_layer(level_tensor)
+
+        P_hat = 1.0 - tf.math.exp(-tf.math.exp(prob_output))
+        num_firms = tf.shape(P_hat)[0]
+        U = tf.random.uniform(shape=[num_firms, 1], minval=0, maxval=1)
+        should_report_level = tf.cast(P_hat > U, dtype=tf.float32)
+
+        return level_output * should_report_level
+
+    def load_weights_from_cfg(self, cfg):
+        # for prob layer
+        level_coefficients = cfg["steps"][0]["coefficients"]
+        level_weights = []
+        for name in self.level_features:
+            if name in level_coefficients:
+                level_weights.append(level_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in level features.")
+
+        level_weights = np.array(level_weights, dtype=np.float32).reshape(
+            len(level_weights), 1
+        )
+        level_bias = np.array([level_coefficients["Intercept"]], dtype=np.float32)
+
+        self.level_layer.w.assign(level_weights)
+        self.level_layer.b.assign(level_bias)
+
+        # for prob layer
+        prob_coefficients = cfg["steps"][1]["coefficients"]
+        prob_weights = []
+        for name in self.prob_features:
+            if name in prob_coefficients:
+                prob_weights.append(prob_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in prob features.")
+
+        prob_weights = np.array(prob_weights, dtype=np.float32).reshape(
+            len(prob_weights), 1
+        )
+        prob_bias = np.array([prob_coefficients["Intercept"]], dtype=np.float32)
+
+        self.prob_layer.w.assign(prob_weights)
+        self.prob_layer.b.assign(prob_bias)
+        print("Weights for 'EDEPMALayer' loaded successfully.")
+
+
+if __name__ == "__main__":
+    # 1. Instantiate the EDEPMALayer
+    edepma_layer = EDEPMALayer()
+    dummy_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
+    _ = edepma_layer(dummy_input)
+
+    edepma_layer.load_weights_from_cfg(EDEPMA_CONFIG)
+
+    loaded_weights = edepma_layer.get_weights()
+    print("Loaded Weights:", loaded_weights)
+    print("EDEPMALayer initialized and weights loaded successfully.")
+
+    test_input = {
+        name: tf.random.uniform((1, 1)) for name in edepma_layer.feature_names
+    }
+    test_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
+
+    prediction = edepma_layer(test_input)
+    print("Prediction:", prediction)

--- a/estimators/layers/edepma_layer.py
+++ b/estimators/layers/edepma_layer.py
@@ -7,8 +7,17 @@ from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
 
 
 class EDEPMALayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'edepma' variable.
+
+    This layer models a two-step process with a probability and a level component.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the EDEPMALayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/fe_layer.py
+++ b/estimators/layers/fe_layer.py
@@ -3,28 +3,30 @@ import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
 from estimators.base_layer.logistic_layer import LogisticLayer
-from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
+from estimators.configs.t13_fi_config import FI_CONFIG
+from estimators.configs.t14_fe_config import FE_CONFIG
 
 
-class EDEPMALayer(tf.keras.layers.Layer):
+class FELayer(tf.keras.layers.Layer):
 
     def __init__(self, **kwargs):
         self.prob_features = [
-            "sumcasht_1",
-            "diffcasht_1",
-            "TDEPMAt_1",
+            "I_BUt",
+            "EDEPMAt",
+            "SMAt",
+            "I_MAt",
+            "EDEPBUt",
+            "OFAt_1",
             "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
-            "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
-            "dgnp",
+            "BUt_1",
+            "LLt_1",
+            "sumcaclt_1",
+            "diffcaclt_1",
+            "sumdcadclt",
+            "diffdcadclt",
+            "sumdofadllt",
+            "diffdofadllt",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -33,21 +35,22 @@ class EDEPMALayer(tf.keras.layers.Layer):
             "marketw",
         ]
         self.level_features = [
-            "sumcasht_1",
-            "diffcasht_1",
-            "TDEPMAt_1",
+            "I_BUt",
+            "EDEPMAt",
+            "SMAt",
+            "I_MAt",
+            "EDEPBUt",
+            "OFAt_1",
             "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
-            "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
-            "dgnp",
+            "BUt_1",
+            "LLt_1",
+            "sumcaclt_1",
+            "diffcaclt_1",
+            "sumdcadclt",
+            "diffdcadclt",
+            "sumdofadllt",
+            "diffdofadllt",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -61,7 +64,6 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer = HSLayer()
 
     def build(self):
-
         num_prob_features = len(self.prob_features)
         num_level_features = len(self.level_features)
 
@@ -142,25 +144,22 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer.w.assign(level_weights)
         self.level_layer.b.assign(level_bias)
 
-        print("Weights for 'EDEPMALayer' loaded successfully.")
+        print("Weights for 'FELayer' loaded successfully.")
 
 
 if __name__ == "__main__":
-    # 1. Instantiate the EDEPMALayer
-    edepma_layer = EDEPMALayer()
-    dummy_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
-    _ = edepma_layer(dummy_input)
+    # 1. Instantiate the FELayer
+    tflayer = FELayer()
+    dummy_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
+    _ = tflayer(dummy_input)
 
-    edepma_layer.load_weights_from_cfg(EDEPMA_CONFIG)
+    tflayer.load_weights_from_cfg(FE_CONFIG)
 
-    loaded_weights = edepma_layer.get_weights()
+    loaded_weights = tflayer.get_weights()
     print("Loaded Weights:", loaded_weights)
-    print("EDEPMALayer initialized and weights loaded successfully.")
+    print("FELayer initialized and weights loaded successfully.")
 
-    test_input = {
-        name: tf.random.uniform((1, 1)) for name in edepma_layer.feature_names
-    }
-    test_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
+    test_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
 
-    prediction = edepma_layer(test_input)
+    prediction = tflayer(test_input)
     print("Prediction:", prediction)

--- a/estimators/layers/fe_layer.py
+++ b/estimators/layers/fe_layer.py
@@ -8,8 +8,17 @@ from estimators.configs.t14_fe_config import FE_CONFIG
 
 
 class FELayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'fe' variable.
+
+    This layer models a two-step process with a probability and a level component.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the FELayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "I_BUt",
             "EDEPMAt",

--- a/estimators/layers/fi_layer.py
+++ b/estimators/layers/fi_layer.py
@@ -7,8 +7,17 @@ from estimators.configs.t13_fi_config import FI_CONFIG
 
 
 class FILayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'fi' variable.
+
+    This layer models a two-step process with a probability and a level component.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the FILayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "I_BUt",
             "EDEPMAt",

--- a/estimators/layers/fi_layer.py
+++ b/estimators/layers/fi_layer.py
@@ -3,28 +3,29 @@ import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
 from estimators.base_layer.logistic_layer import LogisticLayer
-from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
+from estimators.configs.t13_fi_config import FI_CONFIG
 
 
-class EDEPMALayer(tf.keras.layers.Layer):
+class FILayer(tf.keras.layers.Layer):
 
     def __init__(self, **kwargs):
         self.prob_features = [
-            "sumcasht_1",
-            "diffcasht_1",
-            "TDEPMAt_1",
+            "I_BUt",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "SMAt",
+            "I_MAt",
+            "I_MAt2",
+            "EDEPBUt",
+            "EDEPBUt2",
+            "dcat",
+            "dcat2",
+            "dofat",
+            "OFAt_1",
+            "CAt_1",
             "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
-            "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
-            "dgnp",
+            "BUt_1",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -33,21 +34,22 @@ class EDEPMALayer(tf.keras.layers.Layer):
             "marketw",
         ]
         self.level_features = [
-            "sumcasht_1",
-            "diffcasht_1",
-            "TDEPMAt_1",
+            "I_BUt",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "SMAt",
+            "I_MAt",
+            "I_MAt2",
+            "EDEPBUt",
+            "EDEPBUt2",
+            "dcat",
+            "dcat2",
+            "dofat",
+            "OFAt_1",
+            "CAt_1",
             "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
-            "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
-            "dgnp",
+            "BUt_1",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -61,7 +63,6 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer = HSLayer()
 
     def build(self):
-
         num_prob_features = len(self.prob_features)
         num_level_features = len(self.level_features)
 
@@ -142,25 +143,22 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer.w.assign(level_weights)
         self.level_layer.b.assign(level_bias)
 
-        print("Weights for 'EDEPMALayer' loaded successfully.")
+        print("Weights for 'FILayer' loaded successfully.")
 
 
 if __name__ == "__main__":
-    # 1. Instantiate the EDEPMALayer
-    edepma_layer = EDEPMALayer()
-    dummy_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
-    _ = edepma_layer(dummy_input)
+    # 1. Instantiate the FILayer
+    tflayer = FILayer()
+    dummy_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
+    _ = tflayer(dummy_input)
 
-    edepma_layer.load_weights_from_cfg(EDEPMA_CONFIG)
+    tflayer.load_weights_from_cfg(FI_CONFIG)
 
-    loaded_weights = edepma_layer.get_weights()
+    loaded_weights = tflayer.get_weights()
     print("Loaded Weights:", loaded_weights)
-    print("EDEPMALayer initialized and weights loaded successfully.")
+    print("FILayer initialized and weights loaded successfully.")
 
-    test_input = {
-        name: tf.random.uniform((1, 1)) for name in edepma_layer.feature_names
-    }
-    test_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
+    test_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
 
-    prediction = edepma_layer(test_input)
+    prediction = tflayer(test_input)
     print("Prediction:", prediction)

--- a/estimators/layers/gc_layer.py
+++ b/estimators/layers/gc_layer.py
@@ -7,8 +7,18 @@ from estimators.configs.t18_gc_config import GC_CONFIG
 
 
 class GCLayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'gc' variable.
+
+    This layer models a four-step process with positive and negative probability
+    and level components.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the GCLayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.pos_prob_features = [
             "OIBDt",
             "OIBDt2",

--- a/estimators/layers/gc_layer.py
+++ b/estimators/layers/gc_layer.py
@@ -1,0 +1,269 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.hs_layer import HSLayer
+from estimators.base_layer.logistic_layer import LogisticLayer
+from estimators.configs.t18_gc_config import GC_CONFIG
+
+
+class GCLayer(tf.keras.layers.Layer):
+
+    def __init__(self, **kwargs):
+        self.pos_prob_features = [
+            "OIBDt",
+            "OIBDt2",
+            "OIBDt3",
+            "FIt",
+            "FEt",
+            "TDEPMAt",
+            "TDEPMAt2",
+            "EDEPBUt",
+            "EDEPBUt2",
+            "ZPFt",
+            "dourt",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.neg_prob_features = [
+            "OIBDt",
+            "OIBDt2",
+            "FIt",
+            "FEt",
+            "TDEPMAt",
+            "TDEPMAt2",
+            "EDEPBU",
+            "EDEPBUt2",
+            "ZPFt",
+            "dourt",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.pos_level_features = [
+            "OIBDt",
+            "OIBDt2",
+            "OIBDt3",
+            "FIt",
+            "FEt",
+            "TDEPMAt",
+            "TDEPMAt2",
+            "EDEPBUt",
+            "EDEPBUt2",
+            "ZPFt",
+            "dourt",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.neg_level_features = [
+            "OIBDt",
+            "OIBDt2",
+            "FIt",
+            "FEt",
+            "TDEPMAt",
+            "TDEPMAt2",
+            "EDEPBUt",
+            "EDEPBUt2",
+            "ZPFt",
+            "dourt",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.feature_names = set(
+            self.pos_prob_features
+            + self.neg_prob_features
+            + self.pos_level_features
+            + self.neg_level_features
+        )
+
+        super().__init__(**kwargs)
+        self.pos_prob_layer = LogisticLayer()
+        self.neg_prob_layer = LogisticLayer()
+        self.pos_level_layer = HSLayer()
+        self.neg_level_layer = HSLayer()
+
+    def build(self):
+        num_pos_prob_features = len(self.pos_prob_features)
+        num_neg_prob_features = len(self.neg_prob_features)
+        num_pos_level_features = len(self.pos_level_features)
+        num_neg_level_features = len(self.neg_level_features)
+
+        # Build the probability layer
+        pos_prob_input_shape = tf.TensorShape((None, num_pos_prob_features))
+        self.pos_prob_layer.build(pos_prob_input_shape)
+        neg_prob_input_shape = tf.TensorShape((None, num_neg_prob_features))
+        self.neg_prob_layer.build(neg_prob_input_shape)
+
+        # Build the level layer
+        pos_level_input_shape = tf.TensorShape((None, num_pos_level_features))
+        self.pos_level_layer.build(pos_level_input_shape)
+        neg_level_input_shape = tf.TensorShape((None, num_neg_level_features))
+        self.neg_level_layer.build(neg_level_input_shape)
+
+        all_input_shape = tf.TensorShape((None, len(self.feature_names)))
+        super().build(all_input_shape)
+
+    def _assemble_pos_prob_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.pos_prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_neg_prob_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.neg_prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_pos_level_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.pos_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_neg_level_tensor(self, inputs):
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.neg_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        # check input contains all required features
+        for name in self.feature_names:
+            if name not in inputs:
+                raise ValueError(f"Missing input feature: {name}")
+
+        pos_prob_tensor = self._assemble_pos_prob_tensor(inputs)
+        neg_prob_tensor = self._assemble_neg_prob_tensor(inputs)
+        pos_level_tensor = self._assemble_pos_level_tensor(inputs)
+        neg_level_tensor = self._assemble_neg_level_tensor(inputs)
+
+        eta_pos = self.pos_prob_layer(pos_prob_tensor)
+        eta_neg = self.neg_prob_layer(neg_prob_tensor)
+        pos_levels = self.pos_level_layer(pos_level_tensor)
+        neg_levels = self.neg_level_layer(neg_level_tensor)
+
+        P_hat1 = tf.sigmoid(eta_pos)
+        P_hat2 = tf.sigmoid(eta_neg)
+        P_hat1 = tf.minimum(P_hat1, P_hat2)
+
+        num_firms = tf.shape(P_hat1)[0]
+        U = tf.random.uniform(shape=(num_firms, 1), minval=0, maxval=1)
+
+        is_positive = tf.cast(U < P_hat1, dtype=tf.float32)
+        is_zero = tf.cast((U >= P_hat1) & (U < P_hat2), dtype=tf.float32)
+        is_negative = tf.cast(U >= P_hat2, dtype=tf.float32)
+
+        final_value = (
+            (is_positive * pos_levels) + (is_negative * neg_levels) + (is_zero * 0.0)
+        )
+
+        return final_value
+
+    def load_weights_from_cfg(self, cfg):
+        # for prob layer
+        pos_prob_coefficients = cfg["steps"][0]["coefficients"]
+        pos_prob_weights = []
+        for name in self.pos_prob_features:
+            if name in pos_prob_coefficients:
+                pos_prob_weights.append(pos_prob_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in prob features.")
+
+        pos_prob_weights = np.array(pos_prob_weights, dtype=np.float32).reshape(
+            len(pos_prob_weights), 1
+        )
+        pos_prob_bias = np.array([pos_prob_coefficients["Intercept"]], dtype=np.float32)
+
+        self.pos_prob_layer.w.assign(pos_prob_weights)
+        self.pos_prob_layer.b.assign(pos_prob_bias)
+
+        neg_prob_coefficients = cfg["steps"][1]["coefficients"]
+        neg_prob_weights = []
+        for name in self.neg_prob_features:
+            if name in neg_prob_coefficients:
+                neg_prob_weights.append(neg_prob_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in prob features.")
+
+        neg_prob_weights = np.array(neg_prob_weights, dtype=np.float32).reshape(
+            len(neg_prob_weights), 1
+        )
+        neg_prob_bias = np.array([neg_prob_coefficients["Intercept"]], dtype=np.float32)
+
+        self.neg_prob_layer.w.assign(neg_prob_weights)
+        self.neg_prob_layer.b.assign(neg_prob_bias)
+
+        pos_level_coefficients = cfg["steps"][2]["coefficients"]
+        pos_level_weights = []
+        for name in self.pos_level_features:
+            if name in pos_level_coefficients:
+                pos_level_weights.append(pos_level_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in level features.")
+
+        pos_level_weights = np.array(pos_level_weights, dtype=np.float32).reshape(
+            len(pos_level_weights), 1
+        )
+        pos_level_bias = np.array(
+            [pos_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.pos_level_layer.w.assign(pos_level_weights)
+        self.pos_level_layer.b.assign(pos_level_bias)
+
+        neg_level_coefficients = cfg["steps"][3]["coefficients"]
+        neg_level_weights = []
+        for name in self.neg_level_features:
+            if name in neg_level_coefficients:
+                neg_level_weights.append(neg_level_coefficients[name])
+            else:
+                raise ValueError(f"Missing coefficient for {name} in level features.")
+
+        neg_level_weights = np.array(neg_level_weights, dtype=np.float32).reshape(
+            len(neg_level_weights), 1
+        )
+        neg_level_bias = np.array(
+            [neg_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.neg_level_layer.w.assign(neg_level_weights)
+        self.neg_level_layer.b.assign(neg_level_bias)
+
+        print("Weights for 'GCLayer' loaded successfully.")
+
+
+if __name__ == "__main__":
+    # 1. Instantiate the GCLayer
+    tflayer = GCLayer()
+    dummy_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
+    _ = tflayer(dummy_input)
+
+    tflayer.load_weights_from_cfg(GC_CONFIG)
+
+    loaded_weights = tflayer.get_weights()
+    print("Loaded Weights:", loaded_weights)
+    print("GCLayer initialized and weights loaded successfully.")
+
+    test_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
+
+    prediction = tflayer(test_input)
+    print("Prediction:", prediction)

--- a/estimators/layers/ibu_layer.py
+++ b/estimators/layers/ibu_layer.py
@@ -7,8 +7,17 @@ from estimators.configs.t5_ibu_config import IBU_CONFIG
 
 
 class IBULayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'ibu' variable.
+
+    This layer models a two-step process with a probability and a level component.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the IBULayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/ibu_layer.py
+++ b/estimators/layers/ibu_layer.py
@@ -3,23 +3,21 @@ import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
 from estimators.base_layer.logistic_layer import LogisticLayer
-from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
+from estimators.configs.t5_ibu_config import IBU_CONFIG
 
 
-class EDEPMALayer(tf.keras.layers.Layer):
+class IBULayer(tf.keras.layers.Layer):
 
     def __init__(self, **kwargs):
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "SMAt",
+            "IMAt",
+            "EDEPBUt",
+            "EDEPBUt2",
             "dcat_1",
             "ddmpat_1",
             "ddmpat_12",
@@ -35,18 +33,15 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_features = [
             "sumcasht_1",
             "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
+            "sumcaclt_1",
+            "diffcaclt_1",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "SMAt",
+            "IMAt",
+            "EDEPBUt",
+            "EDEPBUt2",
             "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
             "dgnp",
             "FAAB",
             "Public",
@@ -61,7 +56,6 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer = HSLayer()
 
     def build(self):
-
         num_prob_features = len(self.prob_features)
         num_level_features = len(self.level_features)
 
@@ -142,25 +136,23 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer.w.assign(level_weights)
         self.level_layer.b.assign(level_bias)
 
-        print("Weights for 'EDEPMALayer' loaded successfully.")
+        print("Weights for 'IBULayer' loaded successfully.")
 
 
 if __name__ == "__main__":
-    # 1. Instantiate the EDEPMALayer
-    edepma_layer = EDEPMALayer()
-    dummy_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
-    _ = edepma_layer(dummy_input)
+    # 1. Instantiate the IBULayer
+    ibulayer = IBULayer()
+    dummy_input = {name: tf.zeros((1, 1)) for name in ibulayer.feature_names}
+    _ = ibulayer(dummy_input)
 
-    edepma_layer.load_weights_from_cfg(EDEPMA_CONFIG)
+    ibulayer.load_weights_from_cfg(IBU_CONFIG)
 
-    loaded_weights = edepma_layer.get_weights()
+    loaded_weights = ibulayer.get_weights()
     print("Loaded Weights:", loaded_weights)
-    print("EDEPMALayer initialized and weights loaded successfully.")
+    print("IBULayer initialized and weights loaded successfully.")
 
-    test_input = {
-        name: tf.random.uniform((1, 1)) for name in edepma_layer.feature_names
-    }
-    test_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
+    test_input = {name: tf.random.uniform((1, 1)) for name in ibulayer.feature_names}
+    test_input = {name: tf.zeros((1, 1)) for name in ibulayer.feature_names}
 
-    prediction = edepma_layer(test_input)
+    prediction = ibulayer(test_input)
     print("Prediction:", prediction)

--- a/estimators/layers/ima_layer.py
+++ b/estimators/layers/ima_layer.py
@@ -6,9 +6,17 @@ from estimators.configs.t3_ima_config import IMA_CONFIG
 
 
 class IMALayer(tf.keras.layers.Layer):
-    """Keras Layer for the 'ima' variable."""
+    """A TensorFlow layer for the 'ima' variable.
+
+    This layer uses a Tobit model to estimate the 'ima' variable.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the IMALayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.feature_names = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/ima_layer.py
+++ b/estimators/layers/ima_layer.py
@@ -77,7 +77,7 @@ class IMALayer(tf.keras.layers.Layer):
             len(self.feature_names), 1
         )
         bias = np.array([coefficients["Intercept"]], dtype=np.float32)
-        scale = np.array(cfg["scale"], dtype=np.float32)
+        scale = np.array([cfg["scale"]], dtype=np.float32)
         self.level_layer.w.assign(weights)
         self.level_layer.b.assign(bias)
         self.level_layer.scale.assign(scale)

--- a/estimators/layers/ima_layer.py
+++ b/estimators/layers/ima_layer.py
@@ -1,0 +1,101 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.tobit_layer import TobitLayer
+from estimators.configs.t3_ima_config import IMA_CONFIG
+
+
+class IMALayer(tf.keras.layers.Layer):
+    """Keras Layer for the 'ima' variable."""
+
+    def __init__(self, **kwargs):
+        self.feature_names = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "smat",
+            "I_BUt_1",
+            "EDEPBUt_1",
+            "EDEPBUt_12",
+            "EDEPMAt",
+            "TDEPMAt_1",
+            "TDEPMAt_12",
+            "ddmtdmt_1",
+            "dcat_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "dclt_1",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        super().__init__(**kwargs)
+        self.level_layer = TobitLayer()
+
+    def build(self):
+        num_features = len(self.feature_names)
+        tensor_input_shape = tf.TensorShape((None, num_features))
+        self.level_layer.build(tensor_input_shape)
+        super().build(tensor_input_shape)
+
+    def _assemble_tensor(self, inputs):
+        """Converts input dict to an ordered tensor."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.feature_names
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        """
+        Args:
+            inputs: Dictionary mapping feature names to tensors.
+        Returns:
+            tf.Tensor: Tobit model output, shape [batch, 1].
+        """
+        tensor_input = self._assemble_tensor(inputs)
+        return self.level_layer.call(tensor_input)
+
+    def load_weights_from_cfg(self, cfg):
+        """
+        Loads weights from the configuration dictionary.
+
+        Args:
+            cfg: Configuration dictionary containing model coefficients.
+        """
+        coefficients = cfg["steps"][0]["coefficients"]
+        weights = []
+        for name in self.feature_names:
+            if name in coefficients:
+                weights.append(coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        weights = np.array(weights, dtype=np.float32).reshape(
+            len(self.feature_names), 1
+        )
+        bias = np.array([coefficients["Intercept"]], dtype=np.float32)
+        scale = np.array(cfg["scale"], dtype=np.float32)
+        self.level_layer.w.assign(weights)
+        self.level_layer.b.assign(bias)
+        self.level_layer.scale.assign(scale)
+
+
+if __name__ == "__main__":
+    # Example usage
+    ima_layer = IMALayer()
+
+    dummy_input = {name: tf.zeros((1, 1)) for name in ima_layer.feature_names}
+    _ = ima_layer(dummy_input)
+
+    ima_layer.load_weights_from_cfg(IMA_CONFIG)
+
+    loaded_weights = ima_layer.get_weights()
+    print("Weights loaded successfully:", loaded_weights)
+
+    test_input = {name: tf.zeros((3, 1)) for name in ima_layer.feature_names}
+    output = ima_layer(test_input)
+    print("Output shape:", output.shape)
+    print("Output values:", output.numpy())

--- a/estimators/layers/oa_layer.py
+++ b/estimators/layers/oa_layer.py
@@ -7,7 +7,18 @@ from estimators.configs.t19_oa_config import OA_CONFIG
 
 
 class OALayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'oa' variable.
+
+    This layer models a three-step process with a probability and positive/negative
+    level components.
+    """
+
     def __init__(self, **kwargs):
+        """Initializes the OALayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "dourt",
             "GCt",

--- a/estimators/layers/oa_layer.py
+++ b/estimators/layers/oa_layer.py
@@ -1,0 +1,205 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.hs_layer import HSLayer
+from estimators.base_layer.multinomial_layer import MultinomialLayer
+from estimators.configs.t19_oa_config import OA_CONFIG
+
+
+class OALayer(tf.keras.layers.Layer):
+    def __init__(self, **kwargs):
+        self.prob_features = [
+            "dourt",
+            "GCt",
+            "DTDEPMA",
+            "DZPF",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+
+        self.pos_level_features = [
+            "dourt",
+            "GCt",
+            "DTDEPMA",
+            "DZPF",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.neg_level_features = [
+            "dourt",
+            "GCt",
+            "DTDEPMA",
+            "DZPF",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.feature_names = set(
+            self.prob_features + self.pos_level_features + self.neg_level_features
+        )
+        super().__init__(**kwargs)
+        self.prob_layer = MultinomialLayer()
+        self.pos_level_layer = HSLayer()
+        self.neg_level_layer = HSLayer()
+
+    def build(self):
+        num_prob_features = len(self.prob_features)
+        num_pos_level_features = len(self.pos_level_features)
+        num_neg_level_features = len(self.neg_level_features)
+
+        tensor_input_shape = tf.TensorShape((None, num_prob_features))
+        self.prob_layer.build(tensor_input_shape)
+
+        pos_level_input_shape = tf.TensorShape((None, num_pos_level_features))
+        self.pos_level_layer.build(pos_level_input_shape)
+
+        neg_level_input_shape = tf.TensorShape((None, num_neg_level_features))
+        self.neg_level_layer.build(neg_level_input_shape)
+
+        super().build((None, len(self.feature_names)))
+
+    def _assemble_prob_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for probability features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_pos_level_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for positive level features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.pos_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_neg_level_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for negative level features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.neg_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        """Runs the layer on input data."""
+        prob_tensor = self._assemble_prob_tensor(inputs)
+        pos_level_tensor = self._assemble_pos_level_tensor(inputs)
+        neg_level_tensor = self._assemble_neg_level_tensor(inputs)
+
+        pos_level = self.pos_level_layer(pos_level_tensor)
+        neg_level = self.neg_level_layer(neg_level_tensor)
+
+        prob = self.prob_layer(prob_tensor)
+
+        eta1 = prob[:, 0:1]
+        eta2 = prob[:, 1:2]
+
+        pos_level = tf.maximum(pos_level, 0.0)
+        neg_level = tf.minimum(neg_level, 0.0)
+
+        eta2 = tf.maximum(eta1, eta2)
+
+        P_hat1 = tf.sigmoid(eta1)
+        P_hat2 = tf.sigmoid(eta2)
+
+        num_firms = tf.shape(P_hat1)[0]
+        U = tf.random.uniform(shape=[num_firms, 1], minval=0, maxval=1)
+
+        is_negative = tf.cast(U < P_hat1, dtype=tf.float32)
+        is_zero = tf.cast((U >= P_hat1) & (U < P_hat2), dtype=tf.float32)
+        is_positive = tf.cast(U >= P_hat2, dtype=tf.float32)
+
+        final_value = (
+            (is_positive * pos_level) + (is_negative * neg_level) + (is_zero * 0.0)
+        )
+
+        return final_value
+
+    def load_weights_from_cfg(self, cfg):
+        """Loads weights from a configuration dictionary."""
+        prob_coefficients = cfg["steps"][0]["coefficients"]
+        prob_weights = []
+        for name in self.prob_features:
+            if name in prob_coefficients:
+                prob_weights.append(prob_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        prob_weights = np.array(prob_weights, dtype=np.float32).reshape(
+            len(self.prob_features), 1
+        )
+        prob_bias = np.array(prob_coefficients["Intercept"], dtype=np.float32)
+
+        self.prob_layer.w.assign(prob_weights)
+        self.prob_layer.b.assign(prob_bias)
+
+        pos_level_coefficients = cfg["steps"][1]["coefficients"]
+        pos_level_weights = []
+        for name in self.pos_level_features:
+            if name in pos_level_coefficients:
+                pos_level_weights.append(pos_level_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        pos_level_weights = np.array(pos_level_weights, dtype=np.float32).reshape(
+            len(self.pos_level_features), 1
+        )
+        pos_level_bias = np.array(
+            [pos_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.pos_level_layer.w.assign(pos_level_weights)
+        self.pos_level_layer.b.assign(pos_level_bias)
+
+        neg_level_coefficients = cfg["steps"][2]["coefficients"]
+        neg_level_weights = []
+        for name in self.neg_level_features:
+            if name in neg_level_coefficients:
+                neg_level_weights.append(neg_level_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        neg_level_weights = np.array(neg_level_weights, dtype=np.float32).reshape(
+            len(self.neg_level_features), 1
+        )
+        neg_level_bias = np.array(
+            [neg_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.neg_level_layer.w.assign(neg_level_weights)
+        self.neg_level_layer.b.assign(neg_level_bias)
+
+
+if __name__ == "__main__":
+    # 1. Instantiate the OALayer
+    tf_layer = OALayer()
+    dummy_input = {name: tf.zeros((5, 1)) for name in tf_layer.feature_names}
+    _ = tf_layer(dummy_input)
+
+    # 2. Load weights from configuration
+    tf_layer.load_weights_from_cfg(OA_CONFIG)
+
+    print("OALayer initialized and weights loaded successfully.")
+
+    # 3. Test the layer with dummy input
+    prediction = tf_layer(dummy_input)
+    print("Prediction:", prediction)
+
+    # 4. Print the weights to verify
+    print("Weights:", tf_layer.get_weights())
+
+    # 5. Print the feature names to verify
+    print("Feature Names:", tf_layer.feature_names)

--- a/estimators/layers/oibd_layer.py
+++ b/estimators/layers/oibd_layer.py
@@ -2,29 +2,34 @@ import numpy as np
 import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
-from estimators.configs.t7_dca_config import DCA_CONFIG
+from estimators.configs.t12_oibd_config import OIBD_CONFIG
 
 
-class DCALayer(tf.keras.layers.Layer):
-    """Dedicated estimator for the 'dca' variable."""
+class OIBDLayer(tf.keras.layers.Layer):
+    """Dedicated estimator for the 'oibd' variable."""
 
     def __init__(self, **kwargs):
-        """Initializes DCALayer with feature names."""
+        """Initializes OIBDLayer with feature names."""
         self.feature_names = [
-            "sumcasht_1",
-            "diffcasht_1",
+            "sumcaclt_1",
+            "diffcaclt_1",
+            "MAt_1",
+            "I_MAt",
+            "SMAt",
             "EDEPMAt",
             "EDEPMAt2",
-            "SMAt",
-            "IMAt",
+            "BUt_1",
+            "I_BUt",
             "EDEPBUt",
             "EDEPBUt2",
-            "IBUt",
-            "IBUt2",
-            "IBUt3",
-            "dclt_1",
+            "dcat",
+            "dcat2",
             "ddmpat_1",
             "ddmpat_12",
+            "ddmpat_13",
+            "dcasht_1",
+            "dcasht_12",
+            "dclt",
             "dgnp",
             "FAAB",
             "Public",
@@ -92,31 +97,31 @@ class DCALayer(tf.keras.layers.Layer):
         bias = np.array([coefficients["Intercept"]])
         self.hs_layer.w.assign(weights)
         self.hs_layer.b.assign(bias)
-        print("Weights for 'DCALayer' loaded successfully from config.")
+        print("Weights for 'OIBDLayer' loaded successfully from config.")
 
 
 if __name__ == "__main__":
 
-    # 1. Instantiate the specific layer for 'dca'
-    dca_layer = DCALayer()
+    # 1. Instantiate the specific layer
+    tflayer = OIBDLayer()
     # 2. Build the layer by calling it on dummy data. This creates the weight tensors.
     # The dummy input must be a dictionary with all the required feature keys.
-    dummy_input = {name: tf.zeros((13, 1)) for name in dca_layer.feature_names}
-    _ = dca_layer(dummy_input)
+    dummy_input = {name: tf.zeros((13, 1)) for name in tflayer.feature_names}
+    _ = tflayer(dummy_input)
 
     # 3. Call your new method to load the weights
-    dca_layer.load_weights_from_cfg(DCA_CONFIG)
+    tflayer.load_weights_from_cfg(OIBD_CONFIG)
 
     # 4. Verification Step: Check if the weights were loaded correctly
-    loaded_weights = dca_layer.get_weights()
+    loaded_weights = tflayer.get_weights()
     print("\n--- Verification ---")
     print(f"Bias (Intercept) loaded: {loaded_weights[1][0]}")
     print(
-        f"First weights weight (for '{dca_layer.feature_names[0]}') loaded: {loaded_weights[0]}"
+        f"First weights weight (for '{tflayer.feature_names[0]}') loaded: {loaded_weights[0]}"
     )
 
-    # Now the dca_layer is ready for inference with pre-trained weights
-    test_input = {name: tf.zeros((3, 1)) for name in dca_layer.feature_names}
+    # Now the tflayer is ready for inference with pre-trained weights
+    test_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
 
-    prediction = dca_layer(test_input)
+    prediction = tflayer(test_input)
     tf.print("Prediction for test input:", prediction)

--- a/estimators/layers/oibd_layer.py
+++ b/estimators/layers/oibd_layer.py
@@ -6,10 +6,17 @@ from estimators.configs.t12_oibd_config import OIBD_CONFIG
 
 
 class OIBDLayer(tf.keras.layers.Layer):
-    """Dedicated estimator for the 'oibd' variable."""
+    """A TensorFlow layer for the 'oibd' variable.
+
+    This layer uses a single Heckman-style selection (HS) to model the 'oibd' variable.
+    """
 
     def __init__(self, **kwargs):
-        """Initializes OIBDLayer with feature names."""
+        """Initializes the OIBDLayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.feature_names = [
             "sumcaclt_1",
             "diffcaclt_1",

--- a/estimators/layers/ota_layer.py
+++ b/estimators/layers/ota_layer.py
@@ -7,7 +7,18 @@ from estimators.configs.t21_ota_config import OTA_CONFIG
 
 
 class OTALayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'ota' variable.
+
+    This layer models a three-step process with a probability and positive/negative
+    level components.
+    """
+
     def __init__(self, **kwargs):
+        """Initializes the OTALayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "PALLOt_1",
             "ZPFt",

--- a/estimators/layers/ota_layer.py
+++ b/estimators/layers/ota_layer.py
@@ -1,0 +1,228 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.hs_layer import HSLayer
+from estimators.base_layer.multinomial_layer import MultinomialLayer
+from estimators.configs.t21_ota_config import OTA_CONFIG
+
+
+class OTALayer(tf.keras.layers.Layer):
+    def __init__(self, **kwargs):
+        self.prob_features = [
+            "PALLOt_1",
+            "ZPFt",
+            "TDEPMAt",
+            "TDEPMAt2",
+            "OIBDt",
+            "OIBDt2",
+            "EDEPBUt",
+            "EDEPBUt2",
+            "dourt",
+            "TLt",
+            "FIt",
+            "FEt",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+
+        self.pos_level_features = [
+            "PALLOt_1",
+            "ZPFt",
+            "TDEPMAt",
+            "TDEPMAt2",
+            "OIBDt",
+            "OIBDt2",
+            "EDEPBUt",
+            "EDEPBUt2",
+            "dourt",
+            "TLt",
+            "FIt",
+            "FEt",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.neg_level_features = [
+            "PALLOt_1",
+            "ZPFt",
+            "TDEPMAt",
+            "OIBDt",
+            "OIBDt2",
+            "EDEPBUt",
+            "EDEPBUt2",
+            "dourt",
+            "TLt",
+            "FIt",
+            "FEt",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.feature_names = set(
+            self.prob_features + self.pos_level_features + self.neg_level_features
+        )
+        super().__init__(**kwargs)
+        self.prob_layer = MultinomialLayer()
+        self.pos_level_layer = HSLayer()
+        self.neg_level_layer = HSLayer()
+
+    def build(self):
+        num_prob_features = len(self.prob_features)
+        num_pos_level_features = len(self.pos_level_features)
+        num_neg_level_features = len(self.neg_level_features)
+
+        tensor_input_shape = tf.TensorShape((None, num_prob_features))
+        self.prob_layer.build(tensor_input_shape)
+
+        pos_level_input_shape = tf.TensorShape((None, num_pos_level_features))
+        self.pos_level_layer.build(pos_level_input_shape)
+
+        neg_level_input_shape = tf.TensorShape((None, num_neg_level_features))
+        self.neg_level_layer.build(neg_level_input_shape)
+
+        super().build((None, len(self.feature_names)))
+
+    def _assemble_prob_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for probability features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_pos_level_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for positive level features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.pos_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_neg_level_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for negative level features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.neg_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        """Runs the layer on input data."""
+        prob_tensor = self._assemble_prob_tensor(inputs)
+        pos_level_tensor = self._assemble_pos_level_tensor(inputs)
+        neg_level_tensor = self._assemble_neg_level_tensor(inputs)
+
+        pos_level = self.pos_level_layer(pos_level_tensor)
+        neg_level = self.neg_level_layer(neg_level_tensor)
+
+        prob = self.prob_layer(prob_tensor)
+
+        eta1 = prob[:, 0:1]
+        eta2 = prob[:, 1:2]
+
+        pos_level = tf.maximum(pos_level, 0.0)
+        neg_level = tf.minimum(neg_level, 0.0)
+
+        eta2 = tf.maximum(eta1, eta2)
+
+        P_hat1 = tf.sigmoid(eta1)
+        P_hat2 = tf.sigmoid(eta2)
+
+        num_firms = tf.shape(P_hat1)[0]
+        U = tf.random.uniform(shape=[num_firms, 1], minval=0, maxval=1)
+
+        is_negative = tf.cast(U < P_hat1, dtype=tf.float32)
+        is_zero = tf.cast((U >= P_hat1) & (U < P_hat2), dtype=tf.float32)
+        is_positive = tf.cast(U >= P_hat2, dtype=tf.float32)
+
+        final_value = (
+            (is_positive * pos_level) + (is_negative * neg_level) + (is_zero * 0.0)
+        )
+
+        return final_value
+
+    def load_weights_from_cfg(self, cfg):
+        """Loads weights from a configuration dictionary."""
+        prob_coefficients = cfg["steps"][0]["coefficients"]
+        prob_weights = []
+        for name in self.prob_features:
+            if name in prob_coefficients:
+                prob_weights.append(prob_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        prob_weights = np.array(prob_weights, dtype=np.float32).reshape(
+            len(self.prob_features), 1
+        )
+        prob_bias = np.array(prob_coefficients["Intercept"], dtype=np.float32)
+
+        self.prob_layer.w.assign(prob_weights)
+        self.prob_layer.b.assign(prob_bias)
+
+        pos_level_coefficients = cfg["steps"][1]["coefficients"]
+        pos_level_weights = []
+        for name in self.pos_level_features:
+            if name in pos_level_coefficients:
+                pos_level_weights.append(pos_level_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        pos_level_weights = np.array(pos_level_weights, dtype=np.float32).reshape(
+            len(self.pos_level_features), 1
+        )
+        pos_level_bias = np.array(
+            [pos_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.pos_level_layer.w.assign(pos_level_weights)
+        self.pos_level_layer.b.assign(pos_level_bias)
+
+        neg_level_coefficients = cfg["steps"][2]["coefficients"]
+        neg_level_weights = []
+        for name in self.neg_level_features:
+            if name in neg_level_coefficients:
+                neg_level_weights.append(neg_level_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        neg_level_weights = np.array(neg_level_weights, dtype=np.float32).reshape(
+            len(self.neg_level_features), 1
+        )
+        neg_level_bias = np.array(
+            [neg_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.neg_level_layer.w.assign(neg_level_weights)
+        self.neg_level_layer.b.assign(neg_level_bias)
+
+
+if __name__ == "__main__":
+    # 1. Instantiate the OTALayer
+    tf_layer = OTALayer()
+    dummy_input = {name: tf.zeros((5, 1)) for name in tf_layer.feature_names}
+    _ = tf_layer(dummy_input)
+
+    # 2. Load weights from configuration
+    tf_layer.load_weights_from_cfg(OTA_CONFIG)
+
+    print("OTALayer initialized and weights loaded successfully.")
+
+    # 3. Test the layer with dummy input
+    prediction = tf_layer(dummy_input)
+    print("Prediction:", prediction)
+
+    # 4. Print the weights to verify
+    print("Weights:", tf_layer.get_weights())
+
+    # 5. Print the feature names to verify
+    print("Feature Names:", tf_layer.feature_names)

--- a/estimators/layers/pallo_layer.py
+++ b/estimators/layers/pallo_layer.py
@@ -2,30 +2,21 @@ import numpy as np
 import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
-from estimators.configs.t7_dca_config import DCA_CONFIG
+from estimators.configs.t23_pallo_config import PALLO_CONFIG
 
 
-class DCALayer(tf.keras.layers.Layer):
+class PALLOLayer(tf.keras.layers.Layer):
     """Dedicated estimator for the 'dca' variable."""
 
     def __init__(self, **kwargs):
-        """Initializes DCALayer with feature names."""
+        """Initializes PALLOLayer with feature names."""
         self.feature_names = [
             "sumcasht_1",
             "diffcasht_1",
-            "EDEPMAt",
-            "EDEPMAt2",
-            "SMAt",
-            "IMAt",
-            "EDEPBUt",
-            "EDEPBUt2",
-            "IBUt",
-            "IBUt2",
-            "IBUt3",
-            "dclt_1",
-            "ddmpat_1",
-            "ddmpat_12",
-            "dgnp",
+            "ZPFt",
+            "dmpat_1",
+            "MPAt",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -92,31 +83,31 @@ class DCALayer(tf.keras.layers.Layer):
         bias = np.array([coefficients["Intercept"]])
         self.hs_layer.w.assign(weights)
         self.hs_layer.b.assign(bias)
-        print("Weights for 'DCALayer' loaded successfully from config.")
+        print("Weights for 'PALLOLayer' loaded successfully from config.")
 
 
 if __name__ == "__main__":
 
-    # 1. Instantiate the specific layer for 'dca'
-    dca_layer = DCALayer()
+    # 1. Instantiate the specific layer
+    tflayer = PALLOLayer()
     # 2. Build the layer by calling it on dummy data. This creates the weight tensors.
     # The dummy input must be a dictionary with all the required feature keys.
-    dummy_input = {name: tf.zeros((13, 1)) for name in dca_layer.feature_names}
-    _ = dca_layer(dummy_input)
+    dummy_input = {name: tf.zeros((13, 1)) for name in tflayer.feature_names}
+    _ = tflayer(dummy_input)
 
     # 3. Call your new method to load the weights
-    dca_layer.load_weights_from_cfg(DCA_CONFIG)
+    tflayer.load_weights_from_cfg(PALLO_CONFIG)
 
     # 4. Verification Step: Check if the weights were loaded correctly
-    loaded_weights = dca_layer.get_weights()
+    loaded_weights = tflayer.get_weights()
     print("\n--- Verification ---")
     print(f"Bias (Intercept) loaded: {loaded_weights[1][0]}")
     print(
-        f"First weights weight (for '{dca_layer.feature_names[0]}') loaded: {loaded_weights[0]}"
+        f"First weights weight (for '{tflayer.feature_names[0]}') loaded: {loaded_weights[0]}"
     )
 
-    # Now the dca_layer is ready for inference with pre-trained weights
-    test_input = {name: tf.zeros((3, 1)) for name in dca_layer.feature_names}
+    # Now the tflayer is ready for inference with pre-trained weights
+    test_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
 
-    prediction = dca_layer(test_input)
+    prediction = tflayer(test_input)
     tf.print("Prediction for test input:", prediction)

--- a/estimators/layers/pallo_layer.py
+++ b/estimators/layers/pallo_layer.py
@@ -6,10 +6,17 @@ from estimators.configs.t23_pallo_config import PALLO_CONFIG
 
 
 class PALLOLayer(tf.keras.layers.Layer):
-    """Dedicated estimator for the 'dca' variable."""
+    """A TensorFlow layer for the 'pallo' variable.
+
+    This layer uses a single Heckman-style selection (HS) to model the 'pallo' variable.
+    """
 
     def __init__(self, **kwargs):
-        """Initializes PALLOLayer with feature names."""
+        """Initializes the PALLOLayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.feature_names = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/rot_layer.py
+++ b/estimators/layers/rot_layer.py
@@ -7,8 +7,17 @@ from estimators.configs.t24_rot_config import ROT_CONFIG
 
 
 class ROTLayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'rot' variable.
+
+    This layer models a two-step process with a probability and a level component.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the ROTLayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "sumallozpft",
             "diffallozpft",

--- a/estimators/layers/rot_layer.py
+++ b/estimators/layers/rot_layer.py
@@ -3,27 +3,29 @@ import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
 from estimators.base_layer.logistic_layer import LogisticLayer
-from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
+from estimators.configs.t24_rot_config import ROT_CONFIG
 
 
-class EDEPMALayer(tf.keras.layers.Layer):
+class ROTLayer(tf.keras.layers.Layer):
 
     def __init__(self, **kwargs):
         self.prob_features = [
-            "sumcasht_1",
-            "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
-            "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
+            "sumallozpft",
+            "diffallozpft",
+            "TDEPMAt",
+            "TDEPMAt2",
+            "OIBDt",
+            "OIBDt2",
+            "EDEPBUt",
+            "EDEPBUt2",
+            "OTAt",
+            "OTAt2",
+            "TDEPBUt",
+            "TDEPBUt2",
+            "dourt",
+            "TLt",
+            "FIt",
+            "FEt",
             "dgnp",
             "FAAB",
             "Public",
@@ -33,20 +35,15 @@ class EDEPMALayer(tf.keras.layers.Layer):
             "marketw",
         ]
         self.level_features = [
-            "sumcasht_1",
-            "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
-            "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
+            "sumallozpft",
+            "diffallozpft",
+            "OIBDt",
+            "EDEPBUt",
+            "TDEPBUt",
+            "dourt",
+            "TLt",
+            "FIt",
+            "FEt",
             "dgnp",
             "FAAB",
             "Public",
@@ -61,7 +58,6 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer = HSLayer()
 
     def build(self):
-
         num_prob_features = len(self.prob_features)
         num_level_features = len(self.level_features)
 
@@ -142,25 +138,22 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer.w.assign(level_weights)
         self.level_layer.b.assign(level_bias)
 
-        print("Weights for 'EDEPMALayer' loaded successfully.")
+        print("Weights for 'ROTLayer' loaded successfully.")
 
 
 if __name__ == "__main__":
-    # 1. Instantiate the EDEPMALayer
-    edepma_layer = EDEPMALayer()
-    dummy_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
-    _ = edepma_layer(dummy_input)
+    # 1. Instantiate the ROTLayer
+    tflayer = ROTLayer()
+    dummy_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
+    _ = tflayer(dummy_input)
 
-    edepma_layer.load_weights_from_cfg(EDEPMA_CONFIG)
+    tflayer.load_weights_from_cfg(ROT_CONFIG)
 
-    loaded_weights = edepma_layer.get_weights()
+    loaded_weights = tflayer.get_weights()
     print("Loaded Weights:", loaded_weights)
-    print("EDEPMALayer initialized and weights loaded successfully.")
+    print("ROTLayer initialized and weights loaded successfully.")
 
-    test_input = {
-        name: tf.random.uniform((1, 1)) for name in edepma_layer.feature_names
-    }
-    test_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
+    test_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
 
-    prediction = edepma_layer(test_input)
+    prediction = tflayer(test_input)
     print("Prediction:", prediction)

--- a/estimators/layers/sma_layer.py
+++ b/estimators/layers/sma_layer.py
@@ -7,7 +7,18 @@ from estimators.configs.t2_sma_config import SMA_CONFIG
 
 
 class SMALayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'sma' variable.
+
+    This layer models a three-step process with a probability and positive/negative
+    level components.
+    """
+
     def __init__(self, **kwargs):
+        """Initializes the SMALayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/sma_layer.py
+++ b/estimators/layers/sma_layer.py
@@ -1,0 +1,236 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.hs_layer import HSLayer
+from estimators.base_layer.multinomial_layer import MultinomialLayer
+from estimators.configs.t2_sma_config import SMA_CONFIG
+
+
+class SMALayer(tf.keras.layers.Layer):
+    def __init__(self, **kwargs):
+        self.prob_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "TDEPMAt_1",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "MAt_1",
+            "I_BUt_1",
+            "I_BUt_12",
+            "EDEPBUt_1",
+            "EDEPBUt_12",
+            "ddmtdmt_1",
+            "ddmtdmt_12",
+            "dcat_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "dclt_1",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+
+        self.pos_level_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "EDEPMAt",
+            "MAt_1",
+            "I_BUt_1",
+            "I_BUt_12",
+            "EDEPBUt_1",
+            "EDEPBUt_12",
+            "ddmtdmt_1",
+            "dcat_1",
+            "ddmpat_1",
+            "ddmpat_12",
+            "dclt_1",
+            "dclt_12",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.neg_level_features = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "sumcaclt_1",
+            "diffcaclt_1",
+            "TDEPMAt_1",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "MAt_1",
+            "I_BUt_1",
+            "EDEPBUt_1",
+            "EDEPBUt_12",
+            "ddmtdmt_1",
+            "ddmpat_1",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        self.feature_names = set(
+            self.prob_features + self.pos_level_features + self.neg_level_features
+        )
+        super().__init__(**kwargs)
+        self.prob_layer = MultinomialLayer()
+        self.pos_level_layer = HSLayer()
+        self.neg_level_layer = HSLayer()
+
+    def build(self):
+        num_prob_features = len(self.prob_features)
+        num_pos_level_features = len(self.pos_level_features)
+        num_neg_level_features = len(self.neg_level_features)
+
+        tensor_input_shape = tf.TensorShape((None, num_prob_features))
+        self.prob_layer.build(tensor_input_shape)
+
+        pos_level_input_shape = tf.TensorShape((None, num_pos_level_features))
+        self.pos_level_layer.build(pos_level_input_shape)
+
+        neg_level_input_shape = tf.TensorShape((None, num_neg_level_features))
+        self.neg_level_layer.build(neg_level_input_shape)
+
+        super().build((None, len(self.feature_names)))
+
+    def _assemble_prob_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for probability features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.prob_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_pos_level_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for positive level features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.pos_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def _assemble_neg_level_tensor(self, inputs):
+        """Converts input dict to an ordered tensor for negative level features."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.neg_level_features
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        """Runs the layer on input data."""
+        prob_tensor = self._assemble_prob_tensor(inputs)
+        pos_level_tensor = self._assemble_pos_level_tensor(inputs)
+        neg_level_tensor = self._assemble_neg_level_tensor(inputs)
+
+        pos_level = self.pos_level_layer(pos_level_tensor)
+        neg_level = self.neg_level_layer(neg_level_tensor)
+
+        prob = self.prob_layer(prob_tensor)
+
+        eta1 = prob[:, 0:1]
+        eta2 = prob[:, 1:2]
+
+        pos_level = tf.maximum(pos_level, 0.0)
+        neg_level = tf.minimum(neg_level, 0.0)
+
+        eta2 = tf.maximum(eta1, eta2)
+
+        P_hat1 = tf.sigmoid(eta1)
+        P_hat2 = tf.sigmoid(eta2)
+
+        num_firms = tf.shape(P_hat1)[0]
+        U = tf.random.uniform(shape=[num_firms, 1], minval=0, maxval=1)
+
+        is_negative = tf.cast(U < P_hat1, dtype=tf.float32)
+        is_zero = tf.cast((U >= P_hat1) & (U < P_hat2), dtype=tf.float32)
+        is_positive = tf.cast(U >= P_hat2, dtype=tf.float32)
+
+        final_value = (
+            (is_positive * pos_level) + (is_negative * neg_level) + (is_zero * 0.0)
+        )
+
+        return final_value
+
+    def load_weights_from_cfg(self, cfg):
+        """Loads weights from a configuration dictionary."""
+        prob_coefficients = cfg["steps"][0]["coefficients"]
+        prob_weights = []
+        for name in self.prob_features:
+            if name in prob_coefficients:
+                prob_weights.append(prob_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        prob_weights = np.array(prob_weights, dtype=np.float32).reshape(
+            len(self.prob_features), 1
+        )
+        prob_bias = np.array(prob_coefficients["Intercept"], dtype=np.float32)
+
+        self.prob_layer.w.assign(prob_weights)
+        self.prob_layer.b.assign(prob_bias)
+
+        pos_level_coefficients = cfg["steps"][1]["coefficients"]
+        pos_level_weights = []
+        for name in self.pos_level_features:
+            if name in pos_level_coefficients:
+                pos_level_weights.append(pos_level_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        pos_level_weights = np.array(pos_level_weights, dtype=np.float32).reshape(
+            len(self.pos_level_features), 1
+        )
+        pos_level_bias = np.array(
+            [pos_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.pos_level_layer.w.assign(pos_level_weights)
+        self.pos_level_layer.b.assign(pos_level_bias)
+
+        neg_level_coefficients = cfg["steps"][2]["coefficients"]
+        neg_level_weights = []
+        for name in self.neg_level_features:
+            if name in neg_level_coefficients:
+                neg_level_weights.append(neg_level_coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        neg_level_weights = np.array(neg_level_weights, dtype=np.float32).reshape(
+            len(self.neg_level_features), 1
+        )
+        neg_level_bias = np.array(
+            [neg_level_coefficients["Intercept"]], dtype=np.float32
+        )
+
+        self.neg_level_layer.w.assign(neg_level_weights)
+        self.neg_level_layer.b.assign(neg_level_bias)
+
+
+if __name__ == "__main__":
+    # 1. Instantiate the SMALayer
+    sma_layer = SMALayer()
+    dummy_input = {name: tf.zeros((5, 1)) for name in sma_layer.feature_names}
+    _ = sma_layer(dummy_input)
+
+    # 2. Load weights from configuration
+    sma_layer.load_weights_from_cfg(SMA_CONFIG)
+
+    print("SMALayer initialized and weights loaded successfully.")
+
+    # 3. Test the layer with dummy input
+    prediction = sma_layer(dummy_input)
+    print("Prediction:", prediction)
+
+    # 4. Print the weights to verify
+    print("Weights:", sma_layer.get_weights())
+
+    # 5. Print the feature names to verify
+    print("Feature Names:", sma_layer.feature_names)

--- a/estimators/layers/tdepbu_layer.py
+++ b/estimators/layers/tdepbu_layer.py
@@ -77,7 +77,7 @@ class TDEPBULayer(tf.keras.layers.Layer):
             len(self.feature_names), 1
         )
         bias = np.array([coefficients["Intercept"]], dtype=np.float32)
-        scale = np.array(cfg["scale"], dtype=np.float32)
+        scale = np.array([cfg["scale"]], dtype=np.float32)
         self.level_layer.w.assign(weights)
         self.level_layer.b.assign(bias)
         self.level_layer.scale.assign(scale)

--- a/estimators/layers/tdepbu_layer.py
+++ b/estimators/layers/tdepbu_layer.py
@@ -1,0 +1,101 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.tobit_layer import TobitLayer
+from estimators.configs.t22_tdepbu_config import TDEPBU_CONFIG
+
+
+class TDEPBULayer(tf.keras.layers.Layer):
+    """Keras Layer for the 'tdepbu' variable."""
+
+    def __init__(self, **kwargs):
+        self.feature_names = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "SMAt",
+            "I_MAt",
+            "BUt_1",
+            "BUt_12",
+            "dcat",
+            "dcat2",
+            "dclt",
+            "ddmpat_1",
+            "ddmpat_12",
+            "ddmpat_13",
+            "dgnp",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        super().__init__(**kwargs)
+        self.level_layer = TobitLayer()
+
+    def build(self):
+        num_features = len(self.feature_names)
+        tensor_input_shape = tf.TensorShape((None, num_features))
+        self.level_layer.build(tensor_input_shape)
+        super().build(tensor_input_shape)
+
+    def _assemble_tensor(self, inputs):
+        """Converts input dict to an ordered tensor."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.feature_names
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        """
+        Args:
+            inputs: Dictionary mapping feature names to tensors.
+        Returns:
+            tf.Tensor: Tobit model output, shape [batch, 1].
+        """
+        tensor_input = self._assemble_tensor(inputs)
+        return self.level_layer.call(tensor_input)
+
+    def load_weights_from_cfg(self, cfg):
+        """
+        Loads weights from the configuration dictionary.
+
+        Args:
+            cfg: Configuration dictionary containing model coefficients.
+        """
+        coefficients = cfg["steps"][0]["coefficients"]
+        weights = []
+        for name in self.feature_names:
+            if name in coefficients:
+                weights.append(coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        weights = np.array(weights, dtype=np.float32).reshape(
+            len(self.feature_names), 1
+        )
+        bias = np.array([coefficients["Intercept"]], dtype=np.float32)
+        scale = np.array(cfg["scale"], dtype=np.float32)
+        self.level_layer.w.assign(weights)
+        self.level_layer.b.assign(bias)
+        self.level_layer.scale.assign(scale)
+
+
+if __name__ == "__main__":
+    # Example usage
+    tflayer = TDEPBULayer()
+
+    dummy_input = {name: tf.zeros((1, 1)) for name in tflayer.feature_names}
+    _ = tflayer(dummy_input)
+
+    tflayer.load_weights_from_cfg(TDEPBU_CONFIG)
+
+    loaded_weights = tflayer.get_weights()
+    print("Weights loaded successfully:", loaded_weights)
+
+    test_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
+    output = tflayer(test_input)
+    print("Output shape:", output.shape)
+    print("Output values:", output.numpy())

--- a/estimators/layers/tdepbu_layer.py
+++ b/estimators/layers/tdepbu_layer.py
@@ -6,9 +6,17 @@ from estimators.configs.t22_tdepbu_config import TDEPBU_CONFIG
 
 
 class TDEPBULayer(tf.keras.layers.Layer):
-    """Keras Layer for the 'tdepbu' variable."""
+    """A TensorFlow layer for the 'tdepbu' variable.
+
+    This layer uses a Tobit model to estimate the 'tdepbu' variable.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the TDEPBULayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.feature_names = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/tdepma_layer.py
+++ b/estimators/layers/tdepma_layer.py
@@ -73,7 +73,7 @@ class TDEPMALayer(tf.keras.layers.Layer):
             len(self.feature_names), 1
         )
         bias = np.array([coefficients["Intercept"]], dtype=np.float32)
-        scale = np.array(cfg["scale"], dtype=np.float32)
+        scale = np.array([cfg["scale"]], dtype=np.float32)
         self.level_layer.w.assign(weights)
         self.level_layer.b.assign(bias)
         self.level_layer.scale.assign(scale)

--- a/estimators/layers/tdepma_layer.py
+++ b/estimators/layers/tdepma_layer.py
@@ -1,0 +1,97 @@
+import numpy as np
+import tensorflow as tf
+
+from estimators.base_layer.tobit_layer import TobitLayer
+from estimators.configs.t15_tdepma_config import TDEPMA_CONFIG
+
+
+class TDEPMALayer(tf.keras.layers.Layer):
+    """Keras Layer for the 'tdepma' variable."""
+
+    def __init__(self, **kwargs):
+        self.feature_names = [
+            "sumcasht_1",
+            "diffcasht_1",
+            "SMAt",
+            "EDEPMAt",
+            "EDEPMAt2",
+            "I_MAt",
+            "I_MAt2",
+            "ddmpat_1",
+            "ddmpat_12",
+            "ddmpat_13",
+            "realr",
+            "FAAB",
+            "Public",
+            "ruralare",
+            "largcity",
+            "market",
+            "marketw",
+        ]
+        super().__init__(**kwargs)
+        self.level_layer = TobitLayer()
+
+    def build(self):
+        num_features = len(self.feature_names)
+        tensor_input_shape = tf.TensorShape((None, num_features))
+        self.level_layer.build(tensor_input_shape)
+        super().build(tensor_input_shape)
+
+    def _assemble_tensor(self, inputs):
+        """Converts input dict to an ordered tensor."""
+        feature_tensors = [
+            tf.reshape(inputs[name], (-1, 1)) for name in self.feature_names
+        ]
+        return tf.concat(feature_tensors, axis=1)
+
+    def call(self, inputs):
+        """
+        Args:
+            inputs: Dictionary mapping feature names to tensors.
+        Returns:
+            tf.Tensor: Tobit model output, shape [batch, 1].
+        """
+        tensor_input = self._assemble_tensor(inputs)
+        return self.level_layer.call(tensor_input)
+
+    def load_weights_from_cfg(self, cfg):
+        """
+        Loads weights from the configuration dictionary.
+
+        Args:
+            cfg: Configuration dictionary containing model coefficients.
+        """
+        coefficients = cfg["steps"][0]["coefficients"]
+        weights = []
+        for name in self.feature_names:
+            if name in coefficients:
+                weights.append(coefficients[name])
+            else:
+                raise ValueError(f"Coefficient for {name} not found in config.")
+
+        weights = np.array(weights, dtype=np.float32).reshape(
+            len(self.feature_names), 1
+        )
+        bias = np.array([coefficients["Intercept"]], dtype=np.float32)
+        scale = np.array(cfg["scale"], dtype=np.float32)
+        self.level_layer.w.assign(weights)
+        self.level_layer.b.assign(bias)
+        self.level_layer.scale.assign(scale)
+
+
+if __name__ == "__main__":
+    # Example usage
+    tflayer = TDEPMALayer()
+
+    dummy_input = {name: tf.zeros((1, 1)) for name in tflayer.feature_names}
+    _ = tflayer(dummy_input)
+
+    tflayer.load_weights_from_cfg(TDEPMA_CONFIG)
+
+    loaded_weights = tflayer.get_weights()
+    print("Weights loaded successfully:", loaded_weights)
+
+    test_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
+    output = tflayer(test_input)
+    print("Output shape:", output.shape)
+    print("Output values:", output.numpy())

--- a/estimators/layers/tdepma_layer.py
+++ b/estimators/layers/tdepma_layer.py
@@ -6,9 +6,17 @@ from estimators.configs.t15_tdepma_config import TDEPMA_CONFIG
 
 
 class TDEPMALayer(tf.keras.layers.Layer):
-    """Keras Layer for the 'tdepma' variable."""
+    """A TensorFlow layer for the 'tdepma' variable.
+
+    This layer uses a Tobit model to estimate the 'tdepma' variable.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the TDEPMALayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.feature_names = [
             "sumcasht_1",
             "diffcasht_1",

--- a/estimators/layers/tl_layer.py
+++ b/estimators/layers/tl_layer.py
@@ -7,8 +7,17 @@ from estimators.configs.t20_tl_config import TL_CONFIG
 
 
 class TLLayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'tl' variable.
+
+    This layer models a two-step process with a probability and a level component.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the TLLayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "OIBDt",
             "OIBDt2",

--- a/estimators/layers/zpf_layer.py
+++ b/estimators/layers/zpf_layer.py
@@ -3,28 +3,21 @@ import tensorflow as tf
 
 from estimators.base_layer.hs_layer import HSLayer
 from estimators.base_layer.logistic_layer import LogisticLayer
-from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
+from estimators.configs.t16_zpf_config import ZPF_CONFIG
 
 
-class EDEPMALayer(tf.keras.layers.Layer):
+class ZPFLayer(tf.keras.layers.Layer):
 
     def __init__(self, **kwargs):
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
+            "PALLOt_1",
             "ddmpat_1",
             "ddmpat_12",
-            "dclt_1",
-            "dgnp",
+            "ddmpat_13",
+            "DTDEPMA",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -35,19 +28,10 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_features = [
             "sumcasht_1",
             "diffcasht_1",
-            "TDEPMAt_1",
-            "MAt_1",
-            "I_MAt_1",
-            "I_MAt_12",
-            "EDEPBUt_1",
-            "EDEPBUt_12",
-            "ddmtdmt_1",
-            "ddmtdmt_12",
-            "dcat_1",
+            "PALLOt_1",
             "ddmpat_1",
-            "ddmpat_12",
-            "dclt_1",
-            "dgnp",
+            "DTDEPMA",
+            "realr",
             "FAAB",
             "Public",
             "ruralare",
@@ -61,7 +45,6 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer = HSLayer()
 
     def build(self):
-
         num_prob_features = len(self.prob_features)
         num_level_features = len(self.level_features)
 
@@ -142,25 +125,22 @@ class EDEPMALayer(tf.keras.layers.Layer):
         self.level_layer.w.assign(level_weights)
         self.level_layer.b.assign(level_bias)
 
-        print("Weights for 'EDEPMALayer' loaded successfully.")
+        print("Weights for 'ZPFLayer' loaded successfully.")
 
 
 if __name__ == "__main__":
-    # 1. Instantiate the EDEPMALayer
-    edepma_layer = EDEPMALayer()
-    dummy_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
-    _ = edepma_layer(dummy_input)
+    # 1. Instantiate the ZPFLayer
+    tflayer = ZPFLayer()
+    dummy_input = {name: tf.zeros((3, 1)) for name in tflayer.feature_names}
+    _ = tflayer(dummy_input)
 
-    edepma_layer.load_weights_from_cfg(EDEPMA_CONFIG)
+    tflayer.load_weights_from_cfg(ZPF_CONFIG)
 
-    loaded_weights = edepma_layer.get_weights()
+    loaded_weights = tflayer.get_weights()
     print("Loaded Weights:", loaded_weights)
-    print("EDEPMALayer initialized and weights loaded successfully.")
+    print("ZPFLayer initialized and weights loaded successfully.")
 
-    test_input = {
-        name: tf.random.uniform((1, 1)) for name in edepma_layer.feature_names
-    }
-    test_input = {name: tf.zeros((1, 1)) for name in edepma_layer.feature_names}
+    test_input = {name: tf.ones((3, 1)) for name in tflayer.feature_names}
 
-    prediction = edepma_layer(test_input)
+    prediction = tflayer(test_input)
     print("Prediction:", prediction)

--- a/estimators/layers/zpf_layer.py
+++ b/estimators/layers/zpf_layer.py
@@ -7,8 +7,17 @@ from estimators.configs.t16_zpf_config import ZPF_CONFIG
 
 
 class ZPFLayer(tf.keras.layers.Layer):
+    """A TensorFlow layer for the 'zpf' variable.
+
+    This layer models a two-step process with a probability and a level component.
+    """
 
     def __init__(self, **kwargs):
+        """Initializes the ZPFLayer.
+
+        Args:
+            **kwargs: Keyword arguments for the parent class.
+        """
         self.prob_features = [
             "sumcasht_1",
             "diffcasht_1",

--- a/examples/estimators/layers/README.md
+++ b/examples/estimators/layers/README.md
@@ -1,0 +1,12 @@
+# Example Usage of TensorFlow Layers
+
+This directory contains examples of how to use the custom TensorFlow layers directly, without the `EstimatorFactory`.
+
+## `basic_layer_usage.py`
+
+This example demonstrates the basic workflow of using a layer:
+
+1.  Instantiate the layer.
+2.  Load the weights from its configuration.
+3.  Create a dummy input tensor.
+4.  Run a prediction.

--- a/examples/estimators/layers/basic_layer_usage.py
+++ b/examples/estimators/layers/basic_layer_usage.py
@@ -1,0 +1,53 @@
+"""
+Basic usage example of a custom TensorFlow layer.
+
+This script demonstrates the fundamental workflow:
+1. Instantiate the layer
+2. Load the weights from its configuration
+3. Create a dummy input tensor
+4. Run a prediction
+"""
+
+import os
+
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+import tensorflow as tf
+
+from estimators.layers.dca_layer import DCALayer
+from estimators.configs.t7_dca_config import DCA_CONFIG
+
+
+def run_basic_layer_example():
+    """
+    Demonstrates the basic workflow of using a custom TensorFlow layer.
+    """
+    print("--- Running: Basic Layer Usage Example ---")
+    try:
+        # 1. Instantiate the specific layer for 'dca'
+        dca_layer = DCALayer()
+        print("DCALayer instantiated successfully.")
+
+        # 2. Build the layer by calling it on dummy data. This creates the weight tensors.
+        dummy_input = {name: tf.zeros((13, 1)) for name in dca_layer.feature_names}
+        _ = dca_layer(dummy_input)
+
+        # 3. Load the weights from the configuration
+        dca_layer.load_weights_from_cfg(DCA_CONFIG)
+        print("Weights loaded successfully from config.")
+
+        # 4. Create a test input
+        test_input = {name: tf.random.uniform((3, 1)) for name in dca_layer.feature_names}
+        print(f"Created test input with {len(dca_layer.feature_names)} variables.")
+
+        # 5. Run a prediction
+        prediction = dca_layer(test_input)
+        print(f"Prediction for test input: {prediction.numpy()}")
+
+    except Exception as e:
+        print(f"An error occurred during the basic layer example: {e}")
+    finally:
+        print("--- Finished: Basic Layer Usage Example ---")
+
+
+if __name__ == "__main__":
+    run_basic_layer_example()

--- a/tests/estimators/layers/test_all_layers.py
+++ b/tests/estimators/layers/test_all_layers.py
@@ -1,0 +1,286 @@
+import unittest
+import tensorflow as tf
+
+from estimators.layers.dca_layer import DCALayer
+from estimators.configs.t7_dca_config import DCA_CONFIG
+
+from estimators.layers.dcl_layer import DCLLayer
+from estimators.configs.t9_dcl_config import DCL_CONFIG
+
+from estimators.layers.oibd_layer import OIBDLayer
+from estimators.configs.t12_oibd_config import OIBD_CONFIG
+
+from estimators.layers.pallo_layer import PALLOLayer
+from estimators.configs.t23_pallo_config import PALLO_CONFIG
+
+from estimators.layers.dll_layer import DLLLayer
+from estimators.configs.t8_dll_config import DLL_CONFIG
+from estimators.layers.drr_layer import DRRLayer
+from estimators.configs.t11_drr_config import DRR_CONFIG
+from estimators.layers.edepbu_layer import EDEPBULayer
+from estimators.configs.t4_edepbu_config import EDEPBU_CONFIG
+from estimators.layers.edepma_layer import EDEPMALayer
+from estimators.configs.t1_edepma_config import EDEPMA_CONFIG
+from estimators.layers.fe_layer import FELayer
+from estimators.configs.t14_fe_config import FE_CONFIG
+from estimators.layers.fi_layer import FILayer
+from estimators.configs.t13_fi_config import FI_CONFIG
+from estimators.layers.ibu_layer import IBULayer
+from estimators.configs.t5_ibu_config import IBU_CONFIG
+from estimators.layers.rot_layer import ROTLayer
+from estimators.configs.t24_rot_config import ROT_CONFIG
+from estimators.layers.tl_layer import TLLayer
+from estimators.configs.t20_tl_config import TL_CONFIG
+from estimators.layers.zpf_layer import ZPFLayer
+from estimators.configs.t16_zpf_config import ZPF_CONFIG
+
+from estimators.layers.ima_layer import IMALayer
+from estimators.configs.t3_ima_config import IMA_CONFIG
+from estimators.layers.tdepbu_layer import TDEPBULayer
+from estimators.configs.t22_tdepbu_config import TDEPBU_CONFIG
+from estimators.layers.tdepma_layer import TDEPMALayer
+from estimators.configs.t15_tdepma_config import TDEPMA_CONFIG
+
+from estimators.layers.dour_layer import DOURLayer
+from estimators.configs.t17_dour_config import DOUR_CONFIG
+from estimators.layers.oa_layer import OALayer
+from estimators.configs.t19_oa_config import OA_CONFIG
+from estimators.layers.ota_layer import OTALayer
+from estimators.configs.t21_ota_config import OTA_CONFIG
+from estimators.layers.sma_layer import SMALayer
+from estimators.configs.t2_sma_config import SMA_CONFIG
+
+from estimators.layers.dofa_layer import DOFALayer
+from estimators.configs.t6_dofa_config import DOFA_CONFIG
+from estimators.layers.dsc_layer import DSCLayer
+from estimators.configs.t10_dsc_config import DSC_CONFIG
+from estimators.layers.gc_layer import GCLayer
+from estimators.configs.t18_gc_config import GC_CONFIG
+
+class TestAllLayers(unittest.TestCase):
+    
+    def _test_single_hs_layer(self, layer_class, config):
+        """Tests a single layer that uses HSLayer."""
+        layer = layer_class()
+        dummy_input = {name: tf.zeros((13, 1)) for name in layer.feature_names}
+        _ = layer(dummy_input)
+        layer.load_weights_from_cfg(config)
+
+        # Test output shape
+        prediction = layer(dummy_input)
+        self.assertEqual(prediction.shape, (13, 1))
+
+        # Test weights loading
+        loaded_weights = layer.get_weights()
+        self.assertAlmostEqual(loaded_weights[1][0], config['steps'][0]['coefficients']['Intercept'], places=4)
+        feature_name = layer.feature_names[0]
+        expected_weight = config['steps'][0]['coefficients'][feature_name]
+        self.assertAlmostEqual(loaded_weights[0][0][0], expected_weight, places=4)
+
+    def _test_logistic_hs_layer(self, layer_class, config):
+        """Tests a layer that uses a LogisticLayer and an HSLayer."""
+        layer = layer_class()
+        dummy_input = {name: tf.zeros((13, 1)) for name in layer.feature_names}
+        _ = layer(dummy_input)
+        layer.load_weights_from_cfg(config)
+
+        # Test output shape
+        prediction = layer(dummy_input)
+        self.assertEqual(prediction.shape, (13, 1))
+
+        # Test weights loading for prob_layer
+        prob_weights = layer.prob_layer.get_weights()
+        prob_coeffs = config['steps'][0]['coefficients']
+        self.assertAlmostEqual(prob_weights[1][0], prob_coeffs['Intercept'], places=4)
+        prob_feature_name = layer.prob_features[0]
+        expected_prob_weight = prob_coeffs[prob_feature_name]
+        self.assertAlmostEqual(prob_weights[0][0][0], expected_prob_weight, places=4)
+
+        # Test weights loading for level_layer
+        level_weights = layer.level_layer.get_weights()
+        level_coeffs = config['steps'][1]['coefficients']
+        self.assertAlmostEqual(level_weights[1][0], level_coeffs['Intercept'], places=4)
+        level_feature_name = layer.level_features[0]
+        expected_level_weight = level_coeffs[level_feature_name]
+        self.assertAlmostEqual(level_weights[0][0][0], expected_level_weight, places=4)
+
+    def _test_tobit_layer(self, layer_class, config):
+        """Tests a layer that uses a TobitLayer."""
+        layer = layer_class()
+        dummy_input = {name: tf.zeros((13, 1)) for name in layer.feature_names}
+        _ = layer(dummy_input)
+        layer.load_weights_from_cfg(config)
+
+        # Test output shape
+        prediction = layer(dummy_input)
+        self.assertEqual(prediction.shape, (13, 1))
+
+        # Test weights loading
+        loaded_weights = layer.get_weights()
+        self.assertAlmostEqual(loaded_weights[1][0], config['steps'][0]['coefficients']['Intercept'], places=4)
+        feature_name = layer.feature_names[0]
+        expected_weight = config['steps'][0]['coefficients'][feature_name]
+        self.assertAlmostEqual(loaded_weights[0][0][0], expected_weight, places=4)
+        self.assertAlmostEqual(loaded_weights[2][0], config['scale'], places=4)
+
+    def _test_multinomial_hs_layer(self, layer_class, config):
+        """Tests a layer that uses a MultinomialLayer and two HSLayers."""
+        layer = layer_class()
+        dummy_input = {name: tf.zeros((13, 1)) for name in layer.feature_names}
+        _ = layer(dummy_input)
+        layer.load_weights_from_cfg(config)
+
+        # Test output shape
+        prediction = layer(dummy_input)
+        self.assertEqual(prediction.shape, (13, 1))
+
+        # Test weights loading for prob_layer
+        prob_weights = layer.prob_layer.get_weights()
+        prob_coeffs = config['steps'][0]['coefficients']
+        
+        # Test intercepts
+        for i, intercept in enumerate(prob_coeffs['Intercept']):
+            self.assertAlmostEqual(prob_weights[1][i], intercept, places=4)
+
+        # Test weights
+        for i, feature_name in enumerate(layer.prob_features):
+            expected_weight = prob_coeffs[feature_name]
+            if isinstance(expected_weight, list):
+                for j, weight in enumerate(expected_weight):
+                    self.assertAlmostEqual(prob_weights[0][i][j], weight, places=4)
+            else: # It's a float
+                self.assertAlmostEqual(prob_weights[0][i][0], expected_weight, places=4)
+
+        # Test weights loading for pos_level_layer
+        pos_level_weights = layer.pos_level_layer.get_weights()
+        pos_level_coeffs = config['steps'][1]['coefficients']
+        self.assertAlmostEqual(pos_level_weights[1][0], pos_level_coeffs['Intercept'], places=4)
+        pos_level_feature_name = layer.pos_level_features[0]
+        expected_pos_level_weight = pos_level_coeffs[pos_level_feature_name]
+        self.assertAlmostEqual(pos_level_weights[0][0][0], expected_pos_level_weight, places=4)
+
+        # Test weights loading for neg_level_layer
+        neg_level_weights = layer.neg_level_layer.get_weights()
+        neg_level_coeffs = config['steps'][2]['coefficients']
+        self.assertAlmostEqual(neg_level_weights[1][0], neg_level_coeffs['Intercept'], places=4)
+        neg_level_feature_name = layer.neg_level_features[0]
+        expected_neg_level_weight = neg_level_coeffs[neg_level_feature_name]
+        self.assertAlmostEqual(neg_level_weights[0][0][0], expected_neg_level_weight, places=4)
+
+    def _test_dual_logistic_hs_layer(self, layer_class, config):
+        """Tests a layer that uses two LogisticLayers and two HSLayers."""
+        layer = layer_class()
+        dummy_input = {name: tf.zeros((13, 1)) for name in layer.feature_names}
+        _ = layer(dummy_input)
+        layer.load_weights_from_cfg(config)
+
+        # Test output shape
+        prediction = layer(dummy_input)
+        self.assertEqual(prediction.shape, (13, 1))
+
+        # Test weights loading for pos_prob_layer
+        pos_prob_weights = layer.pos_prob_layer.get_weights()
+        pos_prob_coeffs = config['steps'][0]['coefficients']
+        self.assertAlmostEqual(pos_prob_weights[1][0], pos_prob_coeffs['Intercept'], places=4)
+        pos_prob_feature_name = layer.pos_prob_features[0]
+        expected_pos_prob_weight = pos_prob_coeffs[pos_prob_feature_name]
+        self.assertAlmostEqual(pos_prob_weights[0][0][0], expected_pos_prob_weight, places=4)
+
+        # Test weights loading for neg_prob_layer
+        neg_prob_weights = layer.neg_prob_layer.get_weights()
+        neg_prob_coeffs = config['steps'][1]['coefficients']
+        self.assertAlmostEqual(neg_prob_weights[1][0], neg_prob_coeffs['Intercept'], places=4)
+        neg_prob_feature_name = layer.neg_prob_features[0]
+        expected_neg_prob_weight = neg_prob_coeffs[neg_prob_feature_name]
+        self.assertAlmostEqual(neg_prob_weights[0][0][0], expected_neg_prob_weight, places=4)
+
+        # Test weights loading for pos_level_layer
+        pos_level_weights = layer.pos_level_layer.get_weights()
+        pos_level_coeffs = config['steps'][2]['coefficients']
+        self.assertAlmostEqual(pos_level_weights[1][0], pos_level_coeffs['Intercept'], places=4)
+        pos_level_feature_name = layer.pos_level_features[0]
+        expected_pos_level_weight = pos_level_coeffs[pos_level_feature_name]
+        self.assertAlmostEqual(pos_level_weights[0][0][0], expected_pos_level_weight, places=4)
+
+        # Test weights loading for neg_level_layer
+        neg_level_weights = layer.neg_level_layer.get_weights()
+        neg_level_coeffs = config['steps'][3]['coefficients']
+        self.assertAlmostEqual(neg_level_weights[1][0], neg_level_coeffs['Intercept'], places=4)
+        neg_level_feature_name = layer.neg_level_features[0]
+        expected_neg_level_weight = neg_level_coeffs[neg_level_feature_name]
+        self.assertAlmostEqual(neg_level_weights[0][0][0], expected_neg_level_weight, places=4)
+
+    def test_dca_layer(self):
+        self._test_single_hs_layer(DCALayer, DCA_CONFIG)
+
+    def test_dcl_layer(self):
+        self._test_single_hs_layer(DCLLayer, DCL_CONFIG)
+
+    def test_oibd_layer(self):
+        self._test_single_hs_layer(OIBDLayer, OIBD_CONFIG)
+
+    def test_pallo_layer(self):
+        self._test_single_hs_layer(PALLOLayer, PALLO_CONFIG)
+
+    def test_dll_layer(self):
+        self._test_logistic_hs_layer(DLLLayer, DLL_CONFIG)
+
+    def test_drr_layer(self):
+        self._test_logistic_hs_layer(DRRLayer, DRR_CONFIG)
+
+    def test_edepbu_layer(self): 
+        self._test_logistic_hs_layer(EDEPBULayer, EDEPBU_CONFIG)
+
+    def test_edepma_layer(self):
+        self._test_logistic_hs_layer(EDEPMALayer, EDEPMA_CONFIG)
+
+    def test_fe_layer(self):
+        self._test_logistic_hs_layer(FELayer, FE_CONFIG)
+
+    def test_fi_layer(self):
+        self._test_logistic_hs_layer(FILayer, FI_CONFIG)
+
+    def test_ibu_layer(self):
+        self._test_logistic_hs_layer(IBULayer, IBU_CONFIG)
+
+    def test_rot_layer(self):
+        self._test_logistic_hs_layer(ROTLayer, ROT_CONFIG)
+
+    def test_tl_layer(self):
+        self._test_logistic_hs_layer(TLLayer, TL_CONFIG)
+
+    def test_zpf_layer(self):
+        self._test_logistic_hs_layer(ZPFLayer, ZPF_CONFIG)
+
+    def test_ima_layer(self):
+        self._test_tobit_layer(IMALayer, IMA_CONFIG)
+
+    def test_tdepbu_layer(self):
+        self._test_tobit_layer(TDEPBULayer, TDEPBU_CONFIG)
+
+    def test_tdepma_layer(self):
+        self._test_tobit_layer(TDEPMALayer, TDEPMA_CONFIG)
+
+    def test_dour_layer(self):
+        self._test_multinomial_hs_layer(DOURLayer, DOUR_CONFIG)
+
+    def test_oa_layer(self):
+        self._test_multinomial_hs_layer(OALayer, OA_CONFIG)
+
+    def test_ota_layer(self):
+        self._test_multinomial_hs_layer(OTALayer, OTA_CONFIG)
+
+    def test_sma_layer(self):
+        self._test_multinomial_hs_layer(SMALayer, SMA_CONFIG)
+
+    def test_dofa_layer(self):
+        self._test_dual_logistic_hs_layer(DOFALayer, DOFA_CONFIG)
+
+    def test_dsc_layer(self):
+        self._test_dual_logistic_hs_layer(DSCLayer, DSC_CONFIG)
+
+    def test_gc_layer(self):
+        self._test_dual_logistic_hs_layer(GCLayer, GC_CONFIG)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Introduces 24 custom tf layers with test case and example.

### New Base Layers for Regression and Classification

* Added `HSLayer`, a robust linear regression layer using HS loss, designed to be less sensitive to outliers. (`estimators/base_layer/hs_layer.py`)
* Added `LogisticLayer` for logistic regression, supporting logits and probability outputs. (`estimators/base_layer/logistic_layer.py`)
* Added `MultinomialLayer` for multinomial logistic regression, outputting two logits for binary classification. (`estimators/base_layer/multinomial_layer.py`)
* Added `TobitLayer` for Tobit regression, including a custom method to generate a logistic error term and output censored predictions. (`estimators/base_layer/tobit_layer.py`)

### Dedicated Estimator Layers

For example:

* Introduced `DCALayer`, a layer for the "dca" variable, which assembles input features, applies the `HSLayer`, and includes a method to load weights from a configuration dictionary. Includes a verification/test block. (`estimators/layers/dca_layer.py`)
